### PR TITLE
fix(docs): use lowercase Role enum values in JSON API examples

### DIFF
--- a/docs/uxopian-ai/extending/writing_prompts.md
+++ b/docs/uxopian-ai/extending/writing_prompts.md
@@ -153,7 +153,7 @@ curl -X POST https://your-gateway/api/v1/admin/prompts \
   -H "Content-Type: application/json" \
   -d '{
   "id": "myNewPrompt",
-  "role": "USER",
+  "role": "user",
   "content": "Please explain: [[${question}]]",
   "requiresMultiModalModel": false,
   "requiresFunctionCallingModel": false,

--- a/docs/uxopian-ai/reference/rest_api.md
+++ b/docs/uxopian-ai/reference/rest_api.md
@@ -42,7 +42,7 @@ All endpoints use the base path `/api/v1`. Requests go through the gateway; repl
   "conversation": "optional-conversation-id",
   "inputs": [
     {
-      "role": "USER",
+      "role": "user",
       "content": [
         { "type": "text", "value": "Hello" },
         { "type": "prompt", "value": "promptId", "payload": { "key": "value" } },

--- a/docs/uxopian-ai/understanding/conversations_and_requests.md
+++ b/docs/uxopian-ai/understanding/conversations_and_requests.md
@@ -64,7 +64,7 @@ The REST endpoint is `POST /api/v1/requests`. The request body follows the `Requ
   "conversation": "conv-id-or-null",
   "inputs": [
     {
-      "role": "USER",
+      "role": "user",
       "content": [
         { "type": "prompt", "value": "arenderContext", "payload": { "documentId": "doc-123" } },
         { "type": "text", "value": "Summarize this document." }


### PR DESCRIPTION
The Role enum's @JsonValue serializes to lowercase ("user", "system", "assistant"), but documentation examples showed UPPERCASE. Fixed JSON examples to match actual API output.