### PR TITLE
Fix v2023.19.0 versioning regressions from Classic/Modern refactor

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -109,6 +109,12 @@ jobs:
                     echo "   -> using sidebars_arender_current.ts from ${br}"
                     git show "origin/${br}:sidebars_arender_current.ts" > sidebars_arender_current.ts
                 fi
+
+                # Regenerate .generated/arender-classic/ from this branch's
+                # docs/arender/ before snapshotting. Without this step,
+                # docs:version:arender captures the .generated/arender-classic/
+                # built from master — not the branch's content.
+                node ./scripts/build-arender-docs.mjs
               fi
 
               npx docusaurus "docs:version:${product}" "${ver}"

--- a/.github/workflows/sync-deploy.yml
+++ b/.github/workflows/sync-deploy.yml
@@ -118,6 +118,12 @@ jobs:
                     echo "   -> using sidebars_arender_current.ts from ${br}"
                     git show "origin/${br}:sidebars_arender_current.ts" > sidebars_arender_current.ts
                 fi
+
+                # Regenerate .generated/arender-classic/ from this branch's
+                # docs/arender/ before snapshotting. Without this step,
+                # docs:version:arender captures the .generated/arender-classic/
+                # built from staging — not the branch's content.
+                node ./scripts/build-arender-docs.mjs
               fi
 
               # crée le snapshot de version pour le plugin correspondant

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -1,3 +1,4 @@
+import * as fs from "fs";
 import { themes as prismThemes } from "prism-react-renderer";
 import type { Config } from "@docusaurus/types";
 import type * as Preset from "@docusaurus/preset-classic";
@@ -7,6 +8,44 @@ import remarkVariables from "./scripts/remark-variables.mjs";
 // markdown files at build time via the remarkVariables script,
 // replacing {{version}} placeholders.
 const arenderVersion = "2026.0.0";
+
+// Suppress the "unmaintained" banner only on the LTS — the highest snapshot
+// major strictly below `current`. We allow at most two maintained majors in
+// parallel: `current` (auto, no banner) + LTS. Older majors fall back to the
+// default banner. The function is also gated on snapshot presence so the
+// Docusaurus loop doesn't crash referencing a version whose directory
+// hasn't been created yet (it's built one-by-one in CI).
+//
+// Zero maintenance: shipping v2023.20.0 → CI snapshots it → next build
+// auto-promotes it as LTS. Shipping v2027 (bump arenderVersion + add the
+// arender-v2026.X.Y branch) → v2026 auto-promoted as LTS, v2023 demoted to
+// the default "unmaintained" banner (EOL).
+function arenderVersionOverrides(): Record<string, { banner?: "none" }> {
+    const versionedDir = "arender_versioned_docs";
+    if (!fs.existsSync(versionedDir)) return {};
+
+    const currentMajor = parseInt(arenderVersion.split(".")[0], 10);
+
+    const byMajor: Record<number, { name: string; minor: number; patch: number }[]> = {};
+    for (const entry of fs.readdirSync(versionedDir)) {
+        const m = entry.match(/^version-v(\d+)\.(\d+)\.(\d+)$/);
+        if (!m) continue;
+        const major = parseInt(m[1], 10);
+        if (major >= currentMajor) continue;
+        (byMajor[major] ||= []).push({
+            name: entry.replace(/^version-/, ""),
+            minor: parseInt(m[2], 10),
+            patch: parseInt(m[3], 10),
+        });
+    }
+
+    const legacyMajors = Object.keys(byMajor).map(Number).sort((a, b) => b - a);
+    if (legacyMajors.length === 0) return {};
+
+    const ltsMajor = legacyMajors[0];
+    const list = byMajor[ltsMajor].sort((a, b) => b.minor - a.minor || b.patch - a.patch);
+    return { [list[0].name]: { banner: "none" } };
+}
 
 const flowerDocsVersion = "2025.4.0";
 const flowerDocsArenderVersion = "2023.17.0";
@@ -86,7 +125,10 @@ const config: Config = {
                 numberPrefixParser: false,
                 sidebarPath: require.resolve("./sidebars_arender.ts"),
                 lastVersion: "current",
-                versions: { current: { label: `v${arenderVersion}` } },
+                versions: {
+                    current: { label: `v${arenderVersion}` },
+                    ...arenderVersionOverrides(),
+                },
                 showLastUpdateTime: true,
                 remarkPlugins: [[remarkVariables, { variables: { version: arenderVersion } }]],
             },

--- a/src/css/arender.css
+++ b/src/css/arender.css
@@ -420,8 +420,10 @@
    UXODOCS LAYOUT OVERRIDES
    ================================================================ */
 
-/* Hide secondary nav (redundant with sidebar) */
-[class*="plugin-id-arender"] .secondary-nav--arender {
+/* Hide secondary nav on the v2026 (current) ARender doc layout — redundant with
+   the sidebar there. Older versioned docs (v2023.x) still rely on the secondary
+   nav to surface their top-level categories. */
+[class*="plugin-id-arender"][class*="docs-version-current"] .secondary-nav--arender {
     display: none;
 }
 
@@ -464,8 +466,19 @@
     margin: 0 auto;
 }
 
-/* Prevent secondary nav JS from hiding sidebar items */
-[class*="plugin-id-arender"] .uxo-hidden-by-filter {
+/* The 800px reading width is right for prose, but pages using ARenderCards
+   (the documentation home on legacy versions like v2023.x) need full width
+   for the cards/feed grid to fit more than one column. */
+[class*="plugin-id-arender"] .markdown:has([class*="documentationSection"]) {
+    max-width: none;
+    margin: 0;
+}
+
+/* On the v2026 (current) ARender layout the secondary nav is hidden, so we
+   undo its sidebar-filtering side effect to keep all top-level items visible.
+   Versioned docs (v2023.x) still use the secondary nav and rely on this
+   filtering to scope the sidebar to the active category. */
+[class*="plugin-id-arender"][class*="docs-version-current"] .uxo-hidden-by-filter {
     opacity: 1 !important;
     max-height: none !important;
     margin: unset !important;


### PR DESCRIPTION
## Summary

Fixes 5 regressions on versioned ARender docs (v2023.19.0 today, any future v2023.x) introduced by the AR-18228 Classic/Modern refactor.

### What was broken on prod

1. `/docs/arender/v2023.19.0/` served v2026 content (wrong tree captured by every CI snapshot since the refactor — same root cause as the "can't archive versions anymore" complaint)
2. "No longer actively maintained" banner shown on the last 2023 minor
3. Secondary navbar hidden on versioned arender docs (the only nav source on legacy versions)
4. Sidebar filter (driven by the secondary nav) defeated, showing all top-level categories instead of the active one's children
5. Cards layout on the v2023.19.0 home cramped to 1 column even on wide screens

### Commits

1. **`Regenerate Classic tree inside CI versioning loop`** — root cause of #1: the `arender` plugin reads from `.generated/arender-classic/`, which the loop never rebuilt between branches. Each `docs:version` call captured staging/master's prebuild instead of the branch's content.
2. **`Auto-detect maintained LTS for arender banner suppression`** — fix for #2, generalized: scans `arender_versioned_docs/`, picks the highest minor.patch of the highest major strictly below `current`, marks it `banner: \"none\"`. Zero maintenance on the next 2023 minor; auto-rotates the LTS designation when a new major ships.
3. **`Scope v2026 ARender layout overrides to current version`** — fixes #3, #4, #5 by scoping three `[class*=\"plugin-id-arender\"]` rules to `[class*=\"docs-version-current\"]` and using `:has(documentationSection)` for the cards-layout case so legacy versioned docs keep their intended layout while the v2026 layout stays untouched.

## Test plan

- [x] Reproduced the broken flow locally (snapshot v2023.19.0 captured v2026 content, exactly as on prod)
- [x] Reproduced the corrected flow: snapshot now contains the right branch content (`index.md` + `what-is-arender/` + `features/` etc.)
- [x] `npx docusaurus build` succeeds
- [x] `/docs/arender/v2023.19.0/`: zero occurrences of `theme-doc-version-banner` / \"no longer actively maintained\"
- [x] Visual inspection in browser: secondary navbar present, sidebar filters to the active category, cards layout uses the full width
- [x] Simulated ship of v2023.20.0 locally → auto-promoted as LTS, v2023.19.0 falls back to the default banner
- [x] Simulated bump to \`arenderVersion = \"2027.0.0\"\` + v2026.0.0 snapshot → v2026 auto-promoted as LTS, all v2023 entries become EOL
- [ ] CI run on staging deployment to staging.doc.uxopian.com (post-merge)
- [ ] Visual recheck on staging before merging to master

## Future maintenance

- **New 2023 minor (monthly):** just create the \`arender-v2023.X.Y\` branch. Next CI run auto-picks it as LTS. No code change.
- **New major (v2027, etc.):** bump \`arenderVersion\` in \`docusaurus.config.ts\` + create the \`arender-v\<previous-major>.X.Y\` branch for the last maintained minor of the outgoing major. The previous LTS demotes itself to EOL automatically.