### PR TITLE
Fix loading order for Uxopian AI FlowerDocs scope scripts

### DIFF
--- a/docs/uxopian-ai/how_to/flowerdocs_scope/conf/Script/OpenChatShortcut.xml
+++ b/docs/uxopian-ai/how_to/flowerdocs_scope/conf/Script/OpenChatShortcut.xml
@@ -33,7 +33,7 @@
     </ns2:data>
     <ns2:Tags>
         <ns2:tags name="RegistrationOrder" readOnly="false">
-            <ns2:value>0</ns2:value>
+            <ns2:value>2</ns2:value>
         </ns2:tags>
     </ns2:Tags>
     <ns2:versionSeriesId>OpenChatShortcut</ns2:versionSeriesId>

--- a/docs/uxopian-ai/how_to/flowerdocs_scope/conf/Script/UxoAiAdminShortcut.xml
+++ b/docs/uxopian-ai/how_to/flowerdocs_scope/conf/Script/UxoAiAdminShortcut.xml
@@ -33,7 +33,7 @@
     </ns2:data>
     <ns2:Tags>
         <ns2:tags name="RegistrationOrder" readOnly="false">
-            <ns2:value>0</ns2:value>
+            <ns2:value>2</ns2:value>
         </ns2:tags>
     </ns2:Tags>
     <ns2:versionSeriesId>UxoAiAdminShortcut</ns2:versionSeriesId>

--- a/docs/uxopian-ai/how_to/flowerdocs_scope/conf/Script/refreshToken.xml
+++ b/docs/uxopian-ai/how_to/flowerdocs_scope/conf/Script/refreshToken.xml
@@ -33,7 +33,7 @@
     </ns2:data>
     <ns2:Tags>
         <ns2:tags name="RegistrationOrder" readOnly="false">
-            <ns2:value>0</ns2:value>
+            <ns2:value>2</ns2:value>
         </ns2:tags>
     </ns2:Tags>
     <ns2:versionSeriesId>refreshToken</ns2:versionSeriesId>

--- a/docs/uxopian-ai/how_to/flowerdocs_scope/conf/Script/web-comp.xml
+++ b/docs/uxopian-ai/how_to/flowerdocs_scope/conf/Script/web-comp.xml
@@ -33,7 +33,7 @@
     </ns2:data>
     <ns2:Tags>
         <ns2:tags name="RegistrationOrder" readOnly="false">
-            <ns2:value>0</ns2:value>
+            <ns2:value>2</ns2:value>
         </ns2:tags>
     </ns2:Tags>
     <ns2:versionSeriesId>web-comp</ns2:versionSeriesId>


### PR DESCRIPTION
Set RegistrationOrder to 2 for OpenChatShortcut, UxoAiAdminShortcut, refreshToken, and web-comp so they load after consts (0) and uxoai-utils (1).