### PR TITLE
Allow "-" in full-text search docs FD-17605

### DIFF
--- a/docs/flowerdocs/concepts/search/search.md
+++ b/docs/flowerdocs/concepts/search/search.md
@@ -75,9 +75,7 @@ The full-text search function is based on the OpenSearch search function, with t
     - Searching for “\{word A\} OR \{word B\}” retrieves documents containing word A, word B or both words, but does not retrieve documents containing neither word.
     - Searching for “\{word A\} AND NOT \{word B\}” retrieves documents containing word A, but not word B.
 
-The following characters must not be used in full-text searches: `+`, `-`, `=`, `||`, `>`, `<`, `!`, `(`, `)`, `{`, `}`, `[`, `]`, `^`, `"`, `~`, `*`, `?`, `:`, `\`, `/`
-
-To find a document containing the name "John-Peter", use the search "John Peter".
+The following characters must not be used in full-text searches: `+`, `=`, `||`, `>`, `<`, `!`, `(`, `)`, `{`, `}`, `[`, `]`, `^`, `"`, `~`, `*`, `?`, `:`, `\`, `/`
 
 :::info
 Full-text search works only on documents whose content has been indexed beforehand. The content is indexed using a [operation subscription](/docs/flowerdocs/config/core/operation/handlers/fulltext).


### PR DESCRIPTION
## Summary
- Remove `-` from the list of forbidden characters in the FlowerDocs full-text search documentation.
- Drop the now-obsolete "John-Peter" workaround example.

Mirrors the FlowerDocs change in [FD-17500](https://arondor.atlassian.net/browse/FD-17500), merged for v2026 — the dash is no longer rejected in full-text searches.

Jira: [FD-17605](https://arondor.atlassian.net/browse/FD-17605)

## Test plan
- [ ] Verify the rendered page on staging: `/docs/flowerdocs/concepts/search#full-text-search`
- [ ] Confirm `-` is no longer in the forbidden characters list
- [ ] Confirm the obsolete `"John-Peter"` example is gone