### PR TITLE
AR-18408 Add release note for v2023.21.0

### DIFF
--- a/scripts/generateARenderReleases.mjs
+++ b/scripts/generateARenderReleases.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
 /**
- * Script de génération des données de release notes ARender
- * Lit les fichiers release-notes.md et génère un JSON avec les métadonnées
+ * ARender release notes data generation script
+ * Reads release-notes.md files and generates a JSON with the metadata
  */
 
 import { readdirSync, readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
@@ -38,15 +38,15 @@ function extractFrontmatter(content) {
 }
 
 function extractDescription(content) {
-    // Retirer le frontmatter
+    // Remove the frontmatter
     const withoutFrontmatter = content.replace(/^---\n[\s\S]*?\n---\n/, '');
 
-    // Chercher le premier paragraphe non vide
+    // Find the first non-empty paragraph
     const lines = withoutFrontmatter.split('\n');
     for (const line of lines) {
         const trimmed = line.trim();
         if (trimmed && !trimmed.startsWith('#') && !trimmed.startsWith(':::')) {
-            // Limiter à 150 caractères
+            // Limit to 150 characters
             return trimmed.length > 150 ? trimmed.substring(0, 150) + '...' : trimmed;
         }
     }
@@ -72,17 +72,17 @@ function compareVersions(a, b) {
 
     if (!vA || !vB) return 0;
 
-    // Trier par année décroissante, puis par major décroissant, puis par minor décroissant
+    // Sort by year descending, then by major descending, then by minor descending
     if (vA.year !== vB.year) return vB.year - vA.year;
     if (vA.major !== vB.major) return vB.major - vA.major;
     return vB.minor - vA.minor;
 }
 
 function main() {
-    console.log('🔍 Recherche des release notes ARender...');
+    console.log('🔍 Looking for ARender release notes...');
 
     if (!existsSync(RELEASE_NOTES_DIR)) {
-        console.error(`❌ Le répertoire ${RELEASE_NOTES_DIR} n'existe pas`);
+        console.error(`❌ The directory ${RELEASE_NOTES_DIR} does not exist`);
         process.exit(1);
     }
 
@@ -90,7 +90,7 @@ function main() {
         .filter(dirent => dirent.isDirectory())
         .map(dirent => dirent.name);
 
-    console.log(`📁 Trouvé ${versionDirs.length} dossiers de version`);
+    console.log(`📁 Found ${versionDirs.length} version directories`);
 
     const releases = [];
 
@@ -99,7 +99,7 @@ function main() {
         const upgradeNotesPath = join(RELEASE_NOTES_DIR, versionDir, 'upgrade-notes.md');
 
         if (!existsSync(releaseNotesPath)) {
-            console.warn(`⚠️  Pas de release-notes.md pour ${versionDir}`);
+            console.warn(`⚠️  No release-notes.md for ${versionDir}`);
             continue;
         }
 
@@ -107,7 +107,7 @@ function main() {
         const frontmatter = extractFrontmatter(content);
 
         if (!frontmatter) {
-            console.warn(`⚠️  Pas de frontmatter pour ${versionDir}`);
+            console.warn(`⚠️  No frontmatter for ${versionDir}`);
             continue;
         }
 
@@ -124,12 +124,12 @@ function main() {
         console.log(`✅ ${versionDir} - ${release.title}`);
     }
 
-    // Trier les releases par version (décroissant)
+    // Sort releases by version (descending)
     releases.sort(compareVersions);
 
-    // Marquer "latest" : une version par année (v2023.x → latest ; v2026.x → latest ; etc.)
-    // La liste est triée par année décroissante puis major/minor décroissants : la première
-    // occurrence de chaque année est donc la version la plus récente de cette année.
+    // Flag "latest": one version per year (v2023.x → latest ; v2026.x → latest ; etc.)
+    // The list is sorted by year descending then major/minor descending, so the first
+    // occurrence of each year is the most recent version for that year.
     const seenYears = new Set();
     for (const release of releases) {
         const parsed = parseVersion(release.version);
@@ -139,17 +139,17 @@ function main() {
         }
     }
 
-    // Écrire le fichier JSON
+    // Write the JSON file
     const outputDir = dirname(OUTPUT_FILE);
     if (!existsSync(outputDir)) {
-        console.log(`📁 Création du répertoire ${outputDir}`);
+        console.log(`📁 Creating directory ${outputDir}`);
         mkdirSync(outputDir, { recursive: true });
     }
 
     writeFileSync(OUTPUT_FILE, JSON.stringify(releases, null, 2), 'utf-8');
 
-    console.log(`\n✅ Généré ${releases.length} releases dans ${OUTPUT_FILE}`);
-    console.log(`📝 Versions : ${releases.map(r => r.version).join(', ')}`);
+    console.log(`\n✅ Generated ${releases.length} releases in ${OUTPUT_FILE}`);
+    console.log(`📝 Versions: ${releases.map(r => r.version).join(', ')}`);
 }
 
 main();

--- a/scripts/generateARenderReleases.mjs
+++ b/scripts/generateARenderReleases.mjs
@@ -127,9 +127,16 @@ function main() {
     // Trier les releases par version (décroissant)
     releases.sort(compareVersions);
 
-    // Ajouter le flag "latest" à la première version
-    if (releases.length > 0) {
-        releases[0].latest = true;
+    // Marquer "latest" : une version par année (v2023.x → latest ; v2026.x → latest ; etc.)
+    // La liste est triée par année décroissante puis major/minor décroissants : la première
+    // occurrence de chaque année est donc la version la plus récente de cette année.
+    const seenYears = new Set();
+    for (const release of releases) {
+        const parsed = parseVersion(release.version);
+        if (parsed && !seenYears.has(parsed.year)) {
+            release.latest = true;
+            seenYears.add(parsed.year);
+        }
     }
 
     // Écrire le fichier JSON

--- a/src/generated/arenderReleases.json
+++ b/src/generated/arenderReleases.json
@@ -20,8 +20,8 @@
   {
     "version": "v2023.20.0",
     "title": "ARender v2023.20.0 – Release Notes",
-    "date": "2026-05-06",
-    "description": "New collapsed state for the document navigator, customizable log configuration, scroll performance with many annotations, faster DirectOffice conversion, PDFOwl 1.24-26 upgrade, and numerous rendering, redaction, and annotation fixes.",
+    "date": "2026-04-30",
+    "description": "New collapsed state for the document navigator, customizable log configuration, faster DirectOffice conversion, PDFOwl 1.24-26 upgrade, and numerous rendering, redaction, and annotation fixes.",
     "slug": "/release-note/arender/v2023.20.0/release-notes",
     "hasUpgradeNotes": true
   },

--- a/src/generated/arenderReleases.json
+++ b/src/generated/arenderReleases.json
@@ -9,13 +9,21 @@
     "latest": true
   },
   {
+    "version": "v2023.21.0",
+    "title": "ARender v2023.21.0 – Release Notes",
+    "date": "2026-05-29",
+    "description": "Email rendering fixes for S/MIME signed messages, embedded images and hyperlinks, PDF hyperlink navigation to named and cross-document destinations, more robust text search, and a security upgrade.",
+    "slug": "/release-note/arender/v2023.21.0/release-notes",
+    "hasUpgradeNotes": true,
+    "latest": true
+  },
+  {
     "version": "v2023.20.0",
     "title": "ARender v2023.20.0 – Release Notes",
     "date": "2026-05-06",
     "description": "New collapsed state for the document navigator, customizable log configuration, scroll performance with many annotations, faster DirectOffice conversion, PDFOwl 1.24-26 upgrade, and numerous rendering, redaction, and annotation fixes.",
     "slug": "/release-note/arender/v2023.20.0/release-notes",
-    "hasUpgradeNotes": true,
-    "latest": true
+    "hasUpgradeNotes": true
   },
   {
     "version": "v2023.19.0",

--- a/src/pages/release-note/arender/v2023.21.0/release-notes.md
+++ b/src/pages/release-note/arender/v2023.21.0/release-notes.md
@@ -1,0 +1,98 @@
+---
+title: "ARender v2023.21.0 – Release Notes"
+draft: false
+date: "2026-05-29"
+weight: -202321
+aliases:
+  - /release/2023.21/
+description: "Email rendering fixes for S/MIME signed messages, embedded images and hyperlinks, PDF hyperlink navigation to named and cross-document destinations, more robust text search, and a security upgrade."
+_build:
+  list: never
+---
+
+import DocLink from '@site/src/components/DocLink';
+
+<div className="arender-release-notes">
+
+> **Upgrade note:** See [v2023.21.0](../upgrade-notes) for detailed instructions.
+
+# ARender v2023.21.0 – Release Notes
+
+ARender 2023.21.0 is a maintenance release on the 2023.x (ARender Classic) line. It focuses on **email rendering**, with fixes for digitally signed (S/MIME) messages, embedded images, and double-encoded hyperlinks, and on **PDF hyperlink navigation**, so that internal named destinations and cross-document links land at the correct in-page position.
+
+The release also hardens **text search** against documents that mix scripts such as Arabic or Hebrew, refines **word-by-word text selection**, and upgrades embedded platform dependencies to address known security advisories.
+
+---
+
+## Security
+
+#### Embedded platform upgraded
+
+`Changed` — Embedded platform dependencies have been upgraded to address known vulnerabilities of critical and high severity in the application server and networking libraries. For detailed information about the specific advisories addressed, please contact [ARender support](https://arondor.atlassian.net/servicedesk/customer/portals).
+
+---
+
+## Bug fixes
+
+#### Digitally signed (S/MIME) emails render correctly
+
+`Fixed` — Digitally signed (S/MIME) email messages no longer render with a garbled attachment appended after the message body. The signed content is now parsed correctly so the email displays as expected.
+
+#### Emails with embedded images now open
+
+`Fixed` — Email messages containing an embedded image no longer fail to open in ARender. These messages now render reliably.
+
+#### Email hyperlinks no longer double-encoded
+
+`Fixed` — Hyperlink URLs extracted from emails were double-encoded by the PDF URI extractor, producing broken links. URLs are now encoded once and resolve correctly.
+
+#### Hyperlinks to named destinations scroll to the right position
+
+`Fixed` — Clicking an internal PDF hyperlink that targets a named destination now scrolls to the precise position recorded in that destination, instead of stopping at the top of the destination page. This matches the behavior of desktop PDF readers.
+
+#### Cross-document hyperlink notifications include the target position
+
+`Fixed` — Click notifications for cross-document (GoToR) hyperlinks now include the target position on top of the target page, consistent with internal (GoTo) hyperlinks. Integrations that listen for link clicks through the JavaScript API can scroll the target document to the correct location.
+
+#### Text search handles combining diacritics
+
+`Fixed` — Running a text search on PDFs that contain Arabic, Hebrew, or other scripts with stacked vowel marks no longer hangs. Search now returns results for these documents instead of timing out without an error.
+
+#### Word-by-word selection excludes leading punctuation
+
+`Fixed` — In word-by-word selection mode (`text.selection.use.legacy=false`), selecting words enclosed in parentheses no longer pulls the opening parenthesis into the selection. Only the word characters are selected, which keeps hyperlink anchors clean.
+
+#### Annotation buttons in the More menu show their active state
+
+`Fixed` — Annotation tool buttons that overflow into the toolbar's More dropdown now receive the active-state highlight when selected, matching the buttons that stay in the visible toolbar. This affects narrower viewports where part of the annotation toolbar collapses into the dropdown.
+
+#### Document link no longer fails on startup
+
+`Fixed` — A race condition when opening a document link at startup (`topPanel.docLink.activateOnStartup=true`) could throw an `IndexOutOfBoundsException`. The startup sequence now opens the document link reliably.
+
+---
+
+## Changelog
+
+| Summary | Issue Type | Key | Linked Issues |
+|---------|------------|-----|---------------|
+| [Rendition] Digitally signed (S/MIME) emails render with garbled child after the body | Issue | AR-18349 | TMAPR-6773 |
+| Email containing image does not open in ARender | Issue | AR-17392 | TMAPR-5657 |
+| [Rendition] Email hyperlink URL is double-encoded by PDF /URI extractor | Issue | AR-18343 | TMAPR-6721 |
+| GoTo hyperlink to named destination: in-page position never applied, view stays at top of page | Issue | AR-18370 | TMAPR-6704 |
+| Cross-document (GoToR) hyperlink click notification missing LEFT_POSITION and TOP_POSITION | Issue | AR-18331 | TMAPR-6717 |
+| [Rendition] PositionTextParser.sortTextPosition throws IllegalArgumentException on PDFs with Arabic combining diacritics | Issue | AR-18357 | TMAPR-6839 |
+| Word-by-word text selection pulls opening parenthesis into the selection when text.selection.use.legacy=false | Issue | AR-18340 | TMAPR-6742 |
+| [HMI] Annotation buttons in More-menu dropdown miss active-state highlight | Issue | AR-18351 | TMAPR-6709 |
+| Race condition in MainScreenSplitPresenter.openDocLink() causes IndexOutOfBoundsException when topPanel.docLink.activateOnStartup=true | Issue | AR-18245 | TMAPR-6395 |
+| [Security] Fix CVEs vulnerability of critical/high level on Tomcat and Netty library | Dev W/O UX | AR-18391 | |
+
+---
+
+## Download
+
+import ARenderDownloads from '@site/src/components/ARenderDownloads';
+
+<ARenderDownloads version="2023.21.0" filter={["rendition", "web-ui", "connector-filenet", "hmi-cm", "plugin-filenet", "plugin-alfresco", "plugin-alfresco-adf", "client-api", "rendition-api"]} />
+
+</div>

--- a/src/pages/release-note/arender/v2023.21.0/upgrade-notes.md
+++ b/src/pages/release-note/arender/v2023.21.0/upgrade-notes.md
@@ -1,0 +1,44 @@
+---
+title: "ARender v2023.21.0 – Upgrade Notes"
+draft: false
+date: "2026-05-29"
+weight: -202321
+_build:
+  list: never
+---
+
+import DocLink from '@site/src/components/DocLink';
+
+> **Release note:** See [v2023.21.0](../release-notes).
+
+## ⚙️ Customization and Configuration
+
+### Changed and Deprecated Properties
+
+No properties were changed or deprecated in this release.
+
+### New Properties
+
+* **`tools.wkhtmltopdf.external.resource.urls.cleared`** (default: `false`): When set to `true`, external resource URLs (e.g. `file://` references or external image links) are stripped from the source HTML before it is handed off to wkhtmltopdf. This prevents EML/HTML conversions from hanging when wkhtmltopdf attempts to fetch unreachable external resources from restricted network environments. Set in the `application.properties` of the TaskConversion module.
+
+  :::info
+  When enabled, images that depend on external URLs are not rendered in the converted document; base64-embedded images and other inline resources are unaffected.
+  :::
+
+### Deleted Properties
+
+No properties were deleted in this release.
+
+## 📦 Product
+
+### Technical Changes and Security
+
+* **Dependencies upgraded**: Improvements to ARender security have been made by upgrading library versions. This proactive approach ensures better protection against vulnerabilities.
+
+## 💻 API
+
+### Cross-document hyperlink notification: new position fields
+
+The notification payload delivered to JavaScript handlers registered via `registerFollowLinkHandler` now includes `LEFT_POSITION` and `TOP_POSITION` for **cross-document (GoToR) hyperlinks** whose target is an XYZ destination, in addition to the `PAGE_TARGET` field that was previously the only positional information available. The behaviour for internal GoTo hyperlinks is unchanged.
+
+**Action required for integrators:** if your `registerFollowLinkHandler` implementation parses the destination string and assumes that `LEFT_POSITION`/`TOP_POSITION` are absent for GoToR actions, update your handler to accept and use these new fields. The returned coordinates are raw PDF coordinates (origin at the bottom-left of the page); rotation correction must be applied client-side if your target documents have rotated pages. See <DocLink version="v2023.21.0" product="arender" to="development/apis/web-ui/javascript/document/">Document JavaScript API</DocLink>.


### PR DESCRIPTION
Adds the release note for ARender v2023.21.0 (2023.x Classic maintenance line).

## Contents
- New `src/pages/release-note/arender/v2023.21.0/release-notes.md`
- Wired into `src/generated/arenderReleases.json` (new entry, set as latest on the 2023.x line; v2023.20.0 demoted)

## Scope
10 tickets from fixVersion 2023.21.0: 1 Security (vague CVE wording), 9 Bug fixes (email rendering, PDF hyperlink navigation, text search, text selection, toolbar active-state, docLink startup race). Excluded: AR-18407 (CI recipe) and AR-18403 (intra-version regression).

## Notes
- `arenderVersion` left at 2026.0.0 (maintenance line, not the latest major)
- Download block uses `filter` to suppress the duplicate component heading
- Date placeholder 2026-05-29; update to the actual GA date before merge if it slips