### PR TITLE
Remove dead JavaDoc links from FlowerDocs documentation FD-18466

### DIFF
--- a/docs/flowerdocs/apis/core/dao.md
+++ b/docs/flowerdocs/apis/core/dao.md
@@ -10,9 +10,4 @@ content_hash: d375da3e772768bc7ccfd75cc3a2074139a24b0f41f395fa02013fd001266f7b
 
 The DAO API enables the development of FlowerDocs connector to access other data repositories.
 
-<br/>
-*The Javadoc is available online:*
-
-[DAO API](https://documentation.flowerdocs.com/javadocs/dao/index.html)
-
 

--- a/docs/flowerdocs/apis/core/intro.md
+++ b/docs/flowerdocs/apis/core/intro.md
@@ -10,9 +10,3 @@ content_hash: cff039094ce7c5534bfc65c7ab99ba62006ca24699270f7189ac21b66d445f37
 
 **FlowerDocs Core** exhibits a set of services to facilitate integration with third-party applications.
 These services can be consumed in various ways, which are described in the following sections.
-
-<br/>
-
-_The javadoc is available online:_
-
-[Core API](https://documentation.flowerdocs.com/javadocs/service/index.html)

--- a/docs/flowerdocs/apis/core/java.md
+++ b/docs/flowerdocs/apis/core/java.md
@@ -80,7 +80,7 @@ _These properties can either be passed in the Spring `application.properties` co
 
 ## Token generation
 
-A user token can also be dynamically generated using the `AuthenticationService` service, which exposes the [login](https://documentation.flowerdocs.com/javadocs/service/com/flower/docs/service/api/security/AuthenticationService.html) method :
+A user token can also be dynamically generated using the `AuthenticationService` service, which exposes the login method :
 
 ```java
 @Autowired

--- a/docs/flowerdocs/apis/jsapi/fact.md
+++ b/docs/flowerdocs/apis/jsapi/fact.md
@@ -45,7 +45,7 @@ In order to provide information on the context in which a fact took place, sever
 | getCreationDate()                  | Action completion date recovery     |
 | setCreationDate(Date date)         | Action completion date modification |
 
-The actions (see [`com.flower.docs.domain.fact.Action`](#javadoc-com-flower-docs-domain-fact-Action)) supported for facts are:
+The actions (see `com.flower.docs.domain.fact.Action`) supported for facts are:
 
 - `CREATE`: Component creation
 - `UPDATE`: Component update
@@ -57,7 +57,7 @@ The actions (see [`com.flower.docs.domain.fact.Action`](#javadoc-com-flower-docs
 
 ## Additional fields
 
-In addition to information natively stored in the facts, additional fields can be stored (or simply displayed) using [`com.flower.docs.domain.common.ResultField`](#javadoc-com-flower-docs-domain-common-ResultField).
+In addition to information natively stored in the facts, additional fields can be stored (or simply displayed) using `com.flower.docs.domain.common.ResultField`.
 
 | Functions                              | Description                    |
 | -------------------------------------- | ------------------------------ |

--- a/docs/flowerdocs/concepts/components/documents.md
+++ b/docs/flowerdocs/concepts/components/documents.md
@@ -24,7 +24,7 @@ In order to restrict access to, or modifications of, a document's content, a num
 
 <br/>
 
-Some actions are only available if the user has write access to the document. To do this, he/she must have the `UPDATE` permission and have reserved the document (see [Reservation](/docs/flowerdocs/concepts/reservations).
+Some actions are only available if the user has write access to the document. To do this, he/she must have the `UPDATE` permission and have reserved the document (see [Reservation](/docs/flowerdocs/concepts/reservations)).
 
 - Attaching the document to a folder: `ATTACH`
 - To delete the document/folder link, the `DETACH` permission is evaluated on the folder, not on the document

--- a/docs/flowerdocs/concepts/components/documents.md
+++ b/docs/flowerdocs/concepts/components/documents.md
@@ -28,10 +28,3 @@ Some actions are only available if the user has write access to the document. To
 
 - Attaching the document to a folder: `ATTACH`
 - To delete the document/folder link, the `DETACH` permission is evaluated on the folder, not on the document
-
-:::info
-To go further, consult the Javadoc:
-
-- [Document](https://flowerdocs.com/javadocs/domain/com/flower/docs/domain/document/Document.html)
-- [Document class](https://flowerdocs.com/javadocs/domain/com/flower/docs/domain/documentclass/DocumentClass.html)
-  :::

--- a/docs/flowerdocs/concepts/components/folders.md
+++ b/docs/flowerdocs/concepts/components/folders.md
@@ -39,11 +39,3 @@ In order to restrict the access or modifications that can be made to a folder, s
 Some actions are only available if the user has write access to the folder. To do this, it must have the `UPDATE` permission and have reserved the folder (see [Reservation](/docs/flowerdocs/concepts/reservations).
 
 - Attaching the folder to another folder: `ATTACH`
-
-<br/>
-:::info
-To go further, consult the Javadoc:
-
-- [Folder](https://flowerdocs.com/javadocs/domain/com/flower/docs/domain/folder/Folder.html)
-- [Folder classes](https://flowerdocs.com/javadocs/domain/com/flower/docs/domain/folderclass/FolderClass.html)
-  :::

--- a/docs/flowerdocs/concepts/components/getting-started.md
+++ b/docs/flowerdocs/concepts/components/getting-started.md
@@ -9,7 +9,7 @@ last_update:
 content_hash: 4565240081abf77499a2d2eaccb988ecb848e19600fecafd00556776cdae5ad5
 ---
 
-The objects handled through the interface and APIs are [components](https://flowerdocs.com/javadocs/domain/com/flower/docs/domain/component/Component.html). Each component is classified according to business or technical criteria using a [component class](/docs/flowerdocs/concepts/classes/getting-started).
+The objects handled through the interface and APIs are components. Each component is classified according to business or technical criteria using a [component class](/docs/flowerdocs/concepts/classes/getting-started).
 
 :::info
 Find out more about the different component categories:

--- a/docs/flowerdocs/concepts/components/tasks.md
+++ b/docs/flowerdocs/concepts/components/tasks.md
@@ -15,7 +15,7 @@ FlowerDocs can be integrated with any workflow engine on the market.
 In FlowerDocs terms, a workflow is a logical sequence of several classes of tasks where each step corresponds to a type of task (a class of tasks).
 
 <br/>
-__Example:__ ``1. Invoice import`` --> ``2. Accounting validation --> ``3. Overhead validation --> ``4. Payment``
+__Example:__ ``1. Invoice import`` --> ``2. Accounting validation`` --> ``3. Overhead validation`` --> ``4. Payment``
 
 These three stages correspond to three classes of tasks, each of which has two types of response:
 

--- a/docs/flowerdocs/concepts/components/tasks.md
+++ b/docs/flowerdocs/concepts/components/tasks.md
@@ -77,10 +77,3 @@ Assigning a task to a user consists in assigning a task from user A to user B.
 This type of assignment can be made even if the task is already assigned to another user.
 
 This type of assignment requires the `ASSIGN` permission.
-
-:::info
-To find out more, take a look at some references:
-
-- [Task](https://flowerdocs.com/javadocs/domain/com/flower/docs/domain/task/Task.html)
-- [Task class](https://flowerdocs.com/javadocs/domain/com/flower/docs/domain/taskclass/TaskClass.html)
-  :::

--- a/docs/flowerdocs/concepts/components/virtual-folders.md
+++ b/docs/flowerdocs/concepts/components/virtual-folders.md
@@ -41,10 +41,3 @@ To restrict access or modifications to a virtual folder, several permissions are
 - Attach the virtual folder to a folder : `ATTACH`
 
 Some actions are only available if the user has write access to the virtual folder. To do this, the permission has to be set on `UPDATE` for this user and this user should have reserved the virtual folder (see [Reservation](/docs/flowerdocs/concepts/reservations)).
-
-:::info
-To go further, consult the Javadoc:
-
-- [Virtual folder](https://flowerdocs.com/javadocs/domain/com/flower/docs/domain/virtualfolder/VirtualFolder.html)
-- [Virtual folder class](https://flowerdocs.com/javadocs/domain/com/flower/docs/domain/virtualfolderclass/VirtualFolderClass.html)
-  :::

--- a/docs/flowerdocs/concepts/operation.md
+++ b/docs/flowerdocs/concepts/operation.md
@@ -12,9 +12,9 @@ content_hash: 05c91c12ff27131b716e6989871ed19752360f881b7824e253a3c1541e3cdc85
 
 ## Principle
 
-The [Operation API](https://flowerdocs.com/javadocs/operation/index.html) reacts to the execution of operations within **FlowerDocs Core**. A **operation** is an action performed by a user on a component.
+The Operation API reacts to the execution of operations within **FlowerDocs Core**. A **operation** is an action performed by a user on a component.
 
-The **operations managers** (or [`com.flower.docs.operation.api.OperationHandler`](#javadoc-com-flower-docs-operation-api-OperationHandler)) are called when an operation is executed to react to it and apply specific processing. They can be called before (_pre-treatment_) or after (_post-processing_) the execution of the operation.
+The **operations managers** (or `com.flower.docs.operation.api.OperationHandler`) are called when an operation is executed to react to it and apply specific processing. They can be called before (_pre-treatment_) or after (_post-processing_) the execution of the operation.
 
 <br/>
 The execution of an *operation* can be divided into three phases:
@@ -53,7 +53,7 @@ Via the administration interface, it is possible to select other fields, notably
 
 ## Operations Manager
 
-An **operations Manager** (or [`com.flower.docs.operation.api.OperationHandler`](#javadoc-com-flower-docs-operation-api-OperationHandler)) is a code fragment called when an operation is executed.
+An **operations Manager** (or `com.flower.docs.operation.api.OperationHandler`) is a code fragment called when an operation is executed.
 They can be divided into three categories:
 
 - [native](/docs/flowerdocs/config/core/operation/handlers/drools) : provided natively by **FlowerDocs Core** and executed within its JVM
@@ -63,4 +63,4 @@ They can be divided into three categories:
 - [hooks](/docs/flowerdocs/config/core/operation/handlers/hook): exposed as REST web services
 
 <br/>
-To contextualize their execution, an object [`com.flower.docs.operation.api.OperationContext`](#javadoc-com-flower-docs-operation-api-OperationContext) is provided as input. The context can be used to retrieve information concerning the execution of the operation, such as the component concerned or the modifications made.
+To contextualize their execution, an object `com.flower.docs.operation.api.OperationContext` is provided as input. The context can be used to retrieve information concerning the execution of the operation, such as the component concerned or the modifications made.

--- a/docs/flowerdocs/concepts/tags/conditionnel.md
+++ b/docs/flowerdocs/concepts/tags/conditionnel.md
@@ -11,7 +11,7 @@ content_hash: 570cdf64ea92de9f00ca613d249e2f676d91b25464e4c15b0c0f0ab7dd3333c4
 
 The `CONDITIONAL` type is used to define conditions on the various choices (or sets of choices) offered to the user in indexing or search forms.
 
-Objects [`com.flower.docs.domain.tagclass.ConditionalAllowedValue`](#javadoc-com-flower-docs-domain-tagclass-ConditionalAllowedValue) supporting multiple conditions can be defined for a given choice. In this case, all that's needed is for one condition to be satisfied for the user to be offered a choice.
+Objects `com.flower.docs.domain.tagclass.ConditionalAllowedValue` supporting multiple conditions can be defined for a given choice. In this case, all that's needed is for one condition to be satisfied for the user to be offered a choice.
 
 # Tag conditions
 

--- a/docs/flowerdocs/concepts/tags/overview.md
+++ b/docs/flowerdocs/concepts/tags/overview.md
@@ -14,7 +14,7 @@ content_hash: 4ac810de8fae5d16cb9f99884dc51389f36639d29c5d82c14e6509f4cb6090f4
 This metadata can be of different types to ensure consistency of the data stored in FlowerDocs.
 
 <br/>
-A [tag class](https://flowerdocs.com/javadocs/domain/com/flower/docs/domain/tagclass/TagClass.html) defines the typology and characteristics of a tag within a scope. 
+A tag class defines the typology and characteristics of a tag within a scope. 
 This tag class applies to all tags associated with components, and is made up of the following elements:
 
 - `id`: technical tag identifier

--- a/docs/flowerdocs/config/core/operation/handlers/context.md
+++ b/docs/flowerdocs/config/core/operation/handlers/context.md
@@ -11,19 +11,19 @@ content_hash: 88a72f7cc37b22b2f6af25f61132b126b7729fcbdd1b7a79358613e457523165
 
 # Principle
 
-When an operation is executed, the context in which it was performed is provided as input, and its type differs according to the original action. The variable `context` contains an object inherited from [`com.flower.docs.operation.api.OperationContext`](#javadoc-com-flower-docs-operation-api-OperationContext).
+When an operation is executed, the context in which it was performed is provided as input, and its type differs according to the original action. The variable `context` contains an object inherited from `com.flower.docs.operation.api.OperationContext`.
 <br/>
 
 # Action context definition
 
 Depending on the action to which the operation is subscribed, the operation context changes:
 <br/>
--- `CREATE`: [`com.flower.docs.operation.api.UpdateComponentOperationContext`](#javadoc-com-flower-docs-operation-api-UpdateComponentOperationContext).
+-- `CREATE`: `com.flower.docs.operation.api.UpdateComponentOperationContext`.
 <br/>
--- `UPDATE`: [`com.flower.docs.operation.api.UpdateComponentOperationContext`](#javadoc-com-flower-docs-operation-api-UpdateComponentOperationContext).
+-- `UPDATE`: `com.flower.docs.operation.api.UpdateComponentOperationContext`.
 <br/>
--- `UPDATE_CONTENT`: [`com.flower.docs.operation.api.UpdateContentOperationContext`](#javadoc-com-flower-docs-operation-api-UpdateContentOperationContext).
+-- `UPDATE_CONTENT`: `com.flower.docs.operation.api.UpdateContentOperationContext`.
 <br/>
--- `ANSWER`: [`com.flower.docs.operation.api.TaskOperationContext`](#javadoc-com-flower-docs-operation-api-TaskOperationContext).
+-- `ANSWER`: `com.flower.docs.operation.api.TaskOperationContext`.
 <br/>
--- `ASSIGN`: [`com.flower.docs.operation.api.TaskOperationContext`](#javadoc-com-flower-docs-operation-api-TaskOperationContext).
+-- `ASSIGN`: `com.flower.docs.operation.api.TaskOperationContext`.

--- a/docs/flowerdocs/config/core/operation/handlers/drools.md
+++ b/docs/flowerdocs/config/core/operation/handlers/drools.md
@@ -27,11 +27,11 @@ The decision table is stored as the content of the document used to configure su
 The conditions and actions defined must be Java code that can be compiled within **FlowerDocs Core**'s JVM.
 To facilitate their development, an object accessible through the variable `util` is made available whose exposed methods are listed [here](/docs/flowerdocs/config/core/appendices/context-util).
 
-In order to contextualize decision-making, the `context` and `component` variables are provided when evaluating a decision table. They can therefore be used in conditions or actions. The `context` variable contains a [`com.flower.docs.operation.api.OperationContext`](#javadoc-com-flower-docs-operation-api-OperationContext) object storing the operation execution context.
+In order to contextualize decision-making, the `context` and `component` variables are provided when evaluating a decision table. They can therefore be used in conditions or actions. The `context` variable contains a `com.flower.docs.operation.api.OperationContext` object storing the operation execution context.
 <br/>
 It is possible to retrieve the component before the action using the `getOld()` method available on the `UpdateComponentOperationContext` or `TaskOperationContext` type `context` variable.
 <br/>
-The `component` variable contains the component (see [`com.flower.docs.domain.component.Component`](#javadoc-com-flower-docs-domain-component-Component)) concerned by the operation (if available).
+The `component` variable contains the component (see `com.flower.docs.domain.component.Component`) concerned by the operation (if available).
 
 :::info
 To manually define this operation handler, the `com.flower.docs.core.tsp.operation.DroolsOperationHandler` identifier can be used as the value of the `OperationHandler` tag.

--- a/docs/flowerdocs/config/core/operation/registration.md
+++ b/docs/flowerdocs/config/core/operation/registration.md
@@ -41,7 +41,7 @@ The tags referenced by this class are used to configure the subscription:
 
 ## Filter evaluation
 
-For each operation subscription, execution filters can be defined through a [`com.flower.docs.domain.search.SearchRequest`](#javadoc-com-flower-docs-domain-search-SearchRequest) object. These filters can be used to restrict the contexts in which an operation handler is executed. In this way, a subscription can be limited to components that meet the configured criteria.
+For each operation subscription, execution filters can be defined through a `com.flower.docs.domain.search.SearchRequest` object. These filters can be used to restrict the contexts in which an operation handler is executed. In this way, a subscription can be limited to components that meet the configured criteria.
 
 :::info
 To restrict the triggering of a billing process to invoices, the administrator sets the class filter equal to `Bill`.
@@ -53,7 +53,7 @@ An operation performed on a component exposes the component concerned through it
 
 ## Storage
 
-Filters are stored through a [`com.flower.docs.domain.search.SearchRequest`](#javadoc-com-flower-docs-domain-search-SearchRequest) object. When saved, this object is serialized (XML) and saved as the document file used to define the subscription.
+Filters are stored through a `com.flower.docs.domain.search.SearchRequest` object. When saved, this object is serialized (XML) and saved as the document file used to define the subscription.
 The naming of the file containing the filters is imposed. Its name should be `request`.
 
 ## Special features

--- a/docs/flowerdocs/learn/concepts/components.md
+++ b/docs/flowerdocs/learn/concepts/components.md
@@ -8,7 +8,7 @@ last_update:
 content_hash: f4b333e5df6bf16e5286583d18e8dd775a5712478be1d65ec5deb14be1327b4b
 ---
 
-The objects manipulated through the interface and APIs are [components](https://flowerdocs.com/javadocs/domain/com/flower/docs/domain/component/Component.html). Each component is classified according to business or technical criteria using a [component class](/docs/flowerdocs/concepts/classes/getting-started).
+The objects manipulated through the interface and APIs are components. Each component is classified according to business or technical criteria using a [component class](/docs/flowerdocs/concepts/classes/getting-started).
 
 :::info
 Find out more about the different component categories:

--- a/docs/flowerdocs/learn/concepts/folders.md
+++ b/docs/flowerdocs/learn/concepts/folders.md
@@ -31,11 +31,3 @@ In order to restrict access to, or modifications of, a document's content, a num
 Some actions are only available if the user has write access to the document. To do this, it must have the `UPDATE` permission and have reserved the folder (see [Reservation](/docs/flowerdocs/concepts/reservations).
 
 - Attach the folder to another folder: `ATTACH`
-
-<br/>
-:::info
-To go further, consult the Javadoc:
-
-- [Folder](https://flowerdocs.com/javadocs/domain/com/flower/docs/domain/folder/Folder.html)
-- [Folder classes](https://flowerdocs.com/javadocs/domain/com/flower/docs/domain/folderclass/FolderClass.html)
-  :::

--- a/docs/flowerdocs/learn/form-search-tutoriel/search-form/criterias.md
+++ b/docs/flowerdocs/learn/form-search-tutoriel/search-form/criterias.md
@@ -71,9 +71,9 @@ The different properties of a criterion :
 
 - `name`: (here equal to `NomClient`) the symbolic name of the tag to be used as a criterion.
 
-- `type`: the type of value to be entered in the field ([Field type](https://flowerdocs.com/javadocs/domain/com/flower/docs/domain/search/Types.html)).
+- `type`: the type of value to be entered in the field (Field type).
 
-- `operator`: the default operator displayed in the search ([Operator](https://flowerdocs.com/javadocs/domain/com/flower/docs/domain/search/Operators.html)).
+- `operator`: the default operator displayed in the search (Operator).
 
 <br/>
 


### PR DESCRIPTION
Documentation update for 2026.0.0.

Jira: https://arondor.atlassian.net/browse/FD-18466