### PR TITLE
Add Product analytics concept page (ARender 2026 docs)

### DIFF
--- a/docs/arender/concepts/product-analytics.md
+++ b/docs/arender/concepts/product-analytics.md
@@ -1,0 +1,79 @@
+---
+viewer: classic
+title: Product analytics
+slug: /concepts/product-analytics
+sidebar_position: 7
+---
+
+# Product analytics
+
+ARender includes a Product Analytics feature powered by Mixpanel, which helps the Uxopian team understand how ARender is used in real-world deployments. It has been part of ARender since version 2023.5.0. The feature is enabled by default and can be disabled with a single configuration property.
+
+## Why product analytics
+
+The goal of product analytics is to help the Uxopian team:
+
+- Gain insight into how features are actually used.
+- Identify the most and least used functionalities.
+- Prioritize enhancements and new developments on the product roadmap.
+
+This keeps ARender aligned with real user needs and improves the experience for everyone.
+
+## Privacy and compliance
+
+Product analytics is **compliant with local data protection laws** and respects user privacy:
+
+- All data is stored in Europe, ensuring compliance with data protection regulations.
+- No document contents, annotations, or metadata are transmitted.
+- The collected data is limited to feature usage metrics only.
+
+Sensitive information never leaves your environment.
+
+## What data is collected
+
+The metrics tracked by the feature are grouped as follows.
+
+### Document usage
+
+- **Opening documents** — tracks document opening, including MIME type, the number of documents opened, the total page count, and the time taken to open the document.
+- **Closing documents** — tracks document closing, including the total page count, the time spent viewing the document, and the number of pages viewed.
+
+### Annotations
+
+- **Annotation CRUD** — the number of annotations created, updated, and deleted, along with their types.
+- **Repeat annotation mode** — usage of the repeat annotation feature.
+
+### Navigation and interaction
+
+- **Lasso** — usage of the lasso feature.
+- **Text search** — usage of the text search feature.
+- **Page rotation** — usage of the rotation feature.
+- **Document zoom** — usage of the zoom feature.
+- **Fullscreen mode** — usage of the fullscreen feature.
+
+### Document manipulation
+
+- **Document builder** — usage of the Document Builder feature.
+- **Document comparison** — usage of the Comparison feature.
+
+### Export and output
+
+- **PDF printing** — usage of the Print feature.
+- **Document download** — usage of the download feature.
+- **Image filtering** — usage of the image filter feature.
+
+## How the data is used
+
+The analytics are reviewed by the Uxopian team solely to improve the user experience:
+
+- Understand how features are being used.
+- Identify pain points or underused functionalities.
+- Prioritize future updates and improvements.
+
+No sensitive document data is ever exposed.
+
+## Configuration
+
+For product analytics to function, ensure that the URL `https://api-eu.mixpanel.com` is reachable from the user's machine.
+
+To disable product analytics, set `arender.data.analytics.enabled` to `false`. See [Viewer configuration](../reference/viewer-configuration.md#global-display) for the full list of properties.


### PR DESCRIPTION
## What

Adds the **Product analytics** concept page to the ARender 2026 documentation. This page existed in the 2023 docs (`learn/product-analytics`) but had no equivalent in the revamped 2026 docs.

## Details

- New file: `docs/arender/concepts/product-analytics.md`
- Placed under **Core concepts** (`sidebar_position: 7`), marked `viewer: classic` to match the analytics property which lives in the Classic-only `reference/viewer-configuration.md`.
- Content adapted from the 2023 page (purpose, privacy/compliance, collected metrics, configuration).
- Mixpanel endpoint documented as the current EU URL `https://api-eu.mixpanel.com` (the old `api-js.mixpanel.com` is obsolete since the EU migration).
- Cross-link points to `../reference/viewer-configuration.md#global-display`.

Verified with `node scripts/build-arender-docs.mjs`: the page lands in the Classic tree only, not the Modern/Horizon tree.