### PR TITLE
docs(fast2): add Content Integrity & Metadata Integrity playbooks

### DIFF
--- a/docs/fast2/playbook/content-integrity.md
+++ b/docs/fast2/playbook/content-integrity.md
@@ -1,0 +1,163 @@
+---
+title: Content Integrity
+sidebar_label: Content Integrity
+sidebar_position: 4
+---
+
+# Proving Nothing Was Lost: Reconciliation & Checksum Validation
+
+When migrating large volumes of content, a recurring requirement is to **verify that no content has been corrupted or lost in transit** — and to be able to prove it. This playbook describes the reconciliation methodology available with Fast2, the trade-offs between the different content-validation strategies, and how mismatching assets are isolated, logged and retried.
+
+It is written to be **system-agnostic**: "source system" and "destination system" stand for whatever you migrate from and to.
+
+:::tip TL;DR
+- Reconciliation in Fast2 means **comparing a property of the source content against the same property of the destination content** after upload.
+- There are three strategies, from cheapest to most thorough: **(1)** compare the content **size**, **(2)** compare a **hash retrieved** from each system's metadata, **(3)** have Fast2 **calculate the hash** itself on both ends and compare.
+- Whatever the strategy, a mismatch routes the asset into a dedicated **workflow sub-branch** — quarantine, human-in-the-loop comparison, delete & retry, CSV logging of mismatching IDs.
+- All of it is configured as **sequential tasks at workflow-design time** — nothing bespoke.
+- **Content checksums are meaningless if the binary is converted in transit** (image → PDF, HTML → image): the bytes change by design, so the hashes will never match.
+:::
+
+```mermaid
+flowchart LR
+    A[Extract from source] --> B[Capture reference value<br/>size / retrieved hash / computed hash]
+    B --> C[Inject into destination]
+    C --> D[Read same value back<br/>from destination]
+    D --> E{Values match?}
+    E -->|Yes| F[Asset validated]
+    E -->|No| G[Route to mismatch sub-branch<br/>quarantine · retry · log]
+```
+
+## Content validation strategies
+
+As for the content, there would be several ways to validate the content (ex/ PDF binary, ≠ metadata) of the migrated assets, from least expensive to most resource/time consuming :
+
+:::warning Important
+**Note that all of these content checksum are irrelevant in case of a content conversion (ex/ image to PDF or HTML to image) occurring during the migration flow.**
+:::
+
+### 1. Rely on the content size
+
+- Extract all the metadata associated to the content, namely the size of it calculated by the source system
+- Perform the injection of the content in the destination system
+- Query the destination system in a post-upload task and ask the destination system for the size of the uploaded content. If they match, it would mean that the content has not been corrupted during the transfer.
+
+<table style={{width:'100%', borderCollapse:'collapse'}}>
+  <thead>
+    <tr>
+      <th style={{backgroundColor:'#2e7d32', color:'white', textAlign:'left', padding:'8px 12px', width:'50%'}}>Benefits</th>
+      <th style={{backgroundColor:'#c62828', color:'white', textAlign:'left', padding:'8px 12px', width:'50%'}}>Drawbacks</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td style={{backgroundColor:'rgba(46,125,50,0.12)', verticalAlign:'top', padding:'8px 12px'}}>
+        <ul style={{listStyle:'none', margin:0, padding:0}}>
+          <li style={{margin:'0 0 4px 0', paddingLeft:'1.6em', textIndent:'-1.6em'}}>✅ Fast</li>
+          <li style={{margin:'0 0 4px 0', paddingLeft:'1.6em', textIndent:'-1.6em'}}>✅ Rely on the source/destination knowledge of the content</li>
+          <li style={{margin:'0 0 4px 0', paddingLeft:'1.6em', textIndent:'-1.6em'}}>✅ Match calculated based on just 2 values (low-to-no resource usage)</li>
+          <li style={{margin:'0 0 4px 0', paddingLeft:'1.6em', textIndent:'-1.6em'}}>✅ No need to fetch the content from the destination</li>
+        </ul>
+      </td>
+      <td style={{backgroundColor:'rgba(198,40,40,0.12)', verticalAlign:'top', padding:'8px 12px'}}>
+        <ul style={{listStyle:'none', margin:0, padding:0}}>
+          <li style={{margin:'0 0 4px 0', paddingLeft:'1.6em', textIndent:'-1.6em'}}>❌ Source and destination systems must know the content size</li>
+          <li style={{margin:'0 0 4px 0', paddingLeft:'1.6em', textIndent:'-1.6em'}}>❌ Dependent on any post-upload business rules processing the content</li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+### 2. Retrieve (≠ calculate) the hash of the content
+
+- Extract the metadata hash value of the content
+- Upload the content into the destination
+- Retrieve the hash value from the destination during a post-migration task, and compare it with the original hash value of the source system.
+
+<table style={{width:'100%', borderCollapse:'collapse'}}>
+  <thead>
+    <tr>
+      <th style={{backgroundColor:'#2e7d32', color:'white', textAlign:'left', padding:'8px 12px', width:'50%'}}>Benefits</th>
+      <th style={{backgroundColor:'#c62828', color:'white', textAlign:'left', padding:'8px 12px', width:'50%'}}>Drawbacks</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td style={{backgroundColor:'rgba(46,125,50,0.12)', verticalAlign:'top', padding:'8px 12px'}}>
+        <ul style={{listStyle:'none', margin:0, padding:0}}>
+          <li style={{margin:'0 0 4px 0', paddingLeft:'1.6em', textIndent:'-1.6em'}}>✅ Takes the same low-to-none resource capacity as the previous method</li>
+          <li style={{margin:'0 0 4px 0', paddingLeft:'1.6em', textIndent:'-1.6em'}}>✅ More reliable than the previous method.</li>
+        </ul>
+      </td>
+      <td style={{backgroundColor:'rgba(198,40,40,0.12)', verticalAlign:'top', padding:'8px 12px'}}>
+        <ul style={{listStyle:'none', margin:0, padding:0}}>
+          <li style={{margin:'0 0 4px 0', paddingLeft:'1.6em', textIndent:'-1.6em'}}>❌ Needs the source+destination system to auto-calculate the hash of the content</li>
+          <li style={{margin:'0 0 4px 0', paddingLeft:'1.6em', textIndent:'-1.6em'}}>❌ Dependent on whether the source/destination systems calculate the format with a different hashing method</li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+### 3. Calculate (≠ retrieve) the hash of the content
+
+- Extract the content from the source
+- Calculate the hash with Fast2 as soon as the content binary is extracted *(formats supported:  MD5, SHA-1, SHA-256, SHA-512 etc)*
+- Upload the content
+- Retrieve (download) the content as it is in the destination
+- Calculate the hash with Fast2
+- Compare it with the original hash calculated right after extraction from the source.
+
+<table style={{width:'100%', borderCollapse:'collapse'}}>
+  <thead>
+    <tr>
+      <th style={{backgroundColor:'#2e7d32', color:'white', textAlign:'left', padding:'8px 12px', width:'50%'}}>Benefits</th>
+      <th style={{backgroundColor:'#c62828', color:'white', textAlign:'left', padding:'8px 12px', width:'50%'}}>Drawbacks</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td style={{backgroundColor:'rgba(46,125,50,0.12)', verticalAlign:'top', padding:'8px 12px'}}>
+        <ul style={{listStyle:'none', margin:0, padding:0}}>
+          <li style={{margin:'0 0 4px 0', paddingLeft:'1.6em', textIndent:'-1.6em'}}>✅ Fast2 will be able to use the same hashing format for both inbound/outbound content binary</li>
+          <li style={{margin:'0 0 4px 0', paddingLeft:'1.6em', textIndent:'-1.6em'}}>✅ Still works even if either the source or destination is not storing the content hash.</li>
+        </ul>
+      </td>
+      <td style={{backgroundColor:'rgba(198,40,40,0.12)', verticalAlign:'top', padding:'8px 12px'}}>
+        <ul style={{listStyle:'none', margin:0, padding:0}}>
+          <li style={{margin:'0 0 4px 0', paddingLeft:'1.6em', textIndent:'-1.6em'}}>❌ Needs resource for reading twice the content for calculating hashes (one after the extraction from the source, a second after the upload from the destination)</li>
+          <li style={{margin:'0 0 4px 0', paddingLeft:'1.6em', textIndent:'-1.6em'}}>❌ Twice sollicitation of the destination (upload the content + download the content to calculate the hash of the content binary as-is in the destination)</li>
+          <li style={{margin:'0 0 4px 0', paddingLeft:'1.6em', textIndent:'-1.6em'}}>❌ Dependent on any post-upload business rules processing the content</li>
+          <li style={{margin:'0 0 4px 0', paddingLeft:'1.6em', textIndent:'-1.6em'}}>❌ Dependent on any pre-download business rules processing the content</li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+:::tip The task behind strategy 3
+Strategy 3 is powered by the [**HashSignTask**](../catalog/tool.md#HashSignTask) (*Compute content hash*) from the catalog. It computes the hash of a content (default `SHA-256`), stores it as metadata, and can directly compare the freshly computed hash against a previously stored value — failing the document when they differ.
+:::
+
+## Handling mismatches
+
+No matter which method (1/, 2/ or 3/) is used, if the content hash does not match, Fast2 will be able to route the “mismatching” migration assets into a specific workflow sub-branch, and/or delete the document in the destination. Sub-branches can trigger:
+
+- storing both contents into a specific folder for visual comparison like human-in-the-loop,
+- Assert the source-output content validity (check the mimetype, number of pages etc)
+- Delete the document in the destination to prevent clutter of false-positive “migrated asset”
+- Delete and retry uploading the content, and re-calculate a 2nd time the hash value, in case there was an issue during the upload phase
+- Store the ID’s of the mismatching documents into a CSV
+
+These post-checksum operations can be done altogether with Fast2, via sequential tasks during the workflow design phase.
+
+## In practice
+
+Pick the lightest strategy that satisfies your integrity requirement: size comparison costs almost nothing but is the weakest signal; calculating the hash on both ends with Fast2 is the strongest, but reads every content twice. Most projects validate the bulk with a cheap strategy and reserve full hashing for the assets that matter most — or run a 100% hash pass when the compliance bar requires it, accepting the extra I/O.
+
+:::info Related
+- [HashSignTask — Compute content hash](../catalog/tool.md#HashSignTask)
+- [Delta Migration](./delta-migration.md) — reconciliation as part of a catch-up phase
+- [Patterns](../advanced/patterns.md) & [Drools](../advanced/drools.md) for conditional routing of mismatches
+:::

--- a/docs/fast2/playbook/index.md
+++ b/docs/fast2/playbook/index.md
@@ -31,5 +31,7 @@ A cookbook tells you how to cook one dish. The playbook tells you how to plan th
 - **[Extracting From a Live ECM](./extracting-from-live-ecm.md)** — the three bulk-extraction methodologies (Clone & Sweep, Snapshot & Drip, Live Trickle), with a decision matrix, throttling controls, and a defensible sizing baseline. Part 1 of the migration series.
 - **[Delta Migration](./delta-migration.md)** — how the target catches up to a source that never stops: the four delta-capture mechanisms, layered reconciliation, cutover patterns, and the sign-off ritual. Part 2 of the migration series.
 - **[Deployment Variants](./deployment-variants.md)** — where to run Fast2 relative to the source and target: on-premise, cloud, hybrid, and AWS Snowball, with the access-control / performance / debugging trade-offs of each.
+- **[Content Integrity](./content-integrity.md)** — proving no content was corrupted or lost in transit: the three content-validation strategies (size, retrieved hash, computed hash), their trade-offs, and how Fast2 isolates, logs and retries mismatching assets.
+- **[Metadata Integrity](./metadata-integrity.md)** — preserving original creation/modification/retention dates and creator/owner identity in the destination, instead of having them overwritten by the migration run.
 
 These articles are written from the field. They name real projects and real failures, because the point of a playbook is to help you avoid repeating them.

--- a/docs/fast2/playbook/metadata-integrity.md
+++ b/docs/fast2/playbook/metadata-integrity.md
@@ -1,0 +1,49 @@
+---
+title: Metadata Integrity
+sidebar_label: Metadata Integrity
+sidebar_position: 5
+---
+
+# Preserving Metadata & System Fields
+
+In many migrations — especially those driven by legal or audit requirements — the **original metadata must be preserved** in the destination: creation dates, retention dates, modification dates, and the identity of the original creator/owner. The risk is that a naive migration overwrites these with the migration date and the migration service account.
+
+This playbook explains how Fast2 keeps original values intact, and what the destination system and the project team must provide for it to work. It is written to be **system-agnostic**: "source system" and "destination system" stand for whatever you migrate from and to.
+
+:::tip TL;DR
+- Fast2 **passes source values through unchanged** unless a mapping step is intentionally configured to transform them.
+- **Dates** are preserved as-is when both systems share the same format and timezone — no conversion needed.
+- **Creator / owner / modifier** are set by *referencing* identities (“profiles”) that must already exist in the destination.
+- **Read-only / system fields** are typically *settable-once-at-creation*: Fast2 sets them at document creation through the destination's official API, using credentials with sufficient permissions.
+- A built-in **migration-asset tracking system** lets you verify the state of any asset at any step; UAT and business validation remain essential.
+:::
+
+## Keeping source values unchanged
+
+If the format of the expected value in the destination is the same as the source (ex/ same date format, numbers stored under *integer* or *String* or *Decimal* data) Fast2 can keep these values and will not update those unless stated otherwise (like, adding a property mapping step updating not only the name — so it fits the expected nomenclature of the destination — but also the value). This would be an “intentional” migration step added during the workflow design phase.
+
+## Tracking and validation
+
+Fast2 provides a migration-asset tracking system where we can check the state (inbound/outbound) of any asset, for any step of the workflow. Of course, validating the absence of side-effects of the configured task is a crucial aspect of the UAT phase of a Fast2 project. Business validation (outside of Fast2, comparing the sample data from the source and from the destination) is highly recommended as well, and is the responsibility of the project team.
+
+## Creator, owner and modifier
+
+As for the users, the destination system must have the “profiles” configured beforehand, so Fast2 is just “linking” these references when setting the creator/owner/modifier when creating these documents in the destination via the API's.
+
+## Dates
+
+As for the Dates, as long as the source and destination systems use the same format (ex/ YYYY-MM-DD'T'hh:mm:ss.SSSS Z) and are on the same timezone, the destination will understand and interpret the input date values directly from the output of the source system, without Fast2 having to convert them.
+
+## Read-only / system fields
+
+As for the *read-only* values, usually they are just settable-only-once-at-creation values. Fast2 needs credentials with sufficient permissions to create documents and force these values, which cannot be updated once they are set during the document creation. For this, Fast2 uses the official destination API's to prevent any discrepancy between a document metadata/references and the destination knowledge of the expected values.
+
+## In practice
+
+Three conditions make read-only field preservation succeed: the **destination must expose** the field at creation time through its API, the migration account must hold **sufficient permissions** to set it, and any referenced identities (creators, owners) must **already exist** in the destination. Confirm these three points early — ideally during the discovery / PoC phase — because they are properties of the destination system, not of Fast2 itself.
+
+:::info Related
+- [Transformation tasks](../catalog/transformer.md) for property mapping
+- [Credentials](../catalog/credentials.md) for configuring the migration account
+- [Content Integrity](./content-integrity.md) — the companion content-validation playbook
+:::


### PR DESCRIPTION
Add two system-agnostic Fast2 playbooks under docs/fast2/playbook/:

- Content Integrity: reconciliation methodology and the three content-validation strategies (size, retrieved hash, Fast2-computed hash via HashSignTask), with colour-coded benefit/drawback tables and the mismatch routing/retry flow.
- Metadata Integrity: preserving original dates and creator/owner in the destination; read-only fields as settable-once-at-creation values.

Also list both in the playbook index "What's in here" section.


Claude-Session: https://claude.ai/code/session_01PcwPw4RfxftL4iM4PWTJq8