### PR TITLE
docs(fast2): remove em/en-dashes and humanize all playbook articles

### DIFF
--- a/docs/fast2/playbook/content-integrity.md
+++ b/docs/fast2/playbook/content-integrity.md
@@ -6,15 +6,15 @@ sidebar_position: 4
 
 # Proving Nothing Was Lost: Reconciliation & Checksum Validation
 
-When migrating large volumes of content, a recurring requirement is to **verify that no content has been corrupted or lost in transit** — and to be able to prove it. This playbook describes the reconciliation methodology available with Fast2, the trade-offs between the different content-validation strategies, and how mismatching assets are isolated, logged and retried.
+Migrate a few billion documents and sooner or later someone asks the uncomfortable question: how do you actually *know* nothing was corrupted or lost on the way over? This page is about how Fast2 answers it. It walks through the reconciliation methodology, the trade-offs between the content-validation strategies, and what Fast2 does with an asset that fails the check.
 
 It is written to be **system-agnostic**: "source system" and "destination system" stand for whatever you migrate from and to.
 
 :::tip TL;DR
 - Reconciliation in Fast2 means **comparing a property of the source content against the same property of the destination content** after upload.
 - There are three strategies, from cheapest to most thorough: **(1)** compare the content **size**, **(2)** compare a **hash retrieved** from each system's metadata, **(3)** have Fast2 **calculate the hash** itself on both ends and compare.
-- Whatever the strategy, a mismatch routes the asset into a dedicated **workflow sub-branch** — quarantine, human-in-the-loop comparison, delete & retry, CSV logging of mismatching IDs.
-- All of it is configured as **sequential tasks at workflow-design time** — nothing bespoke.
+- Whatever the strategy, a mismatch routes the asset into a dedicated **workflow sub-branch**: quarantine, a human-in-the-loop comparison, delete and retry, or just logging the bad IDs to a CSV.
+- All of it is **sequential tasks you wire at workflow-design time**. No bespoke code.
 - **Content checksums are meaningless if the binary is converted in transit** (image → PDF, HTML → image): the bytes change by design, so the hashes will never match.
 :::
 
@@ -137,7 +137,7 @@ As for the content, there would be several ways to validate the content (ex/ PDF
 </table>
 
 :::tip The task behind strategy 3
-Strategy 3 is powered by the [**HashSignTask**](../catalog/tool.md#HashSignTask) (*Compute content hash*) from the catalog. It computes the hash of a content (default `SHA-256`), stores it as metadata, and can directly compare the freshly computed hash against a previously stored value — failing the document when they differ.
+Strategy 3 is powered by the [**HashSignTask**](../catalog/tool.md#HashSignTask) (*Compute content hash*) from the catalog. It computes the hash of a content (default `SHA-256`), stores it as metadata, and can compare that fresh hash against a previously stored one, failing the document when the two don't match.
 :::
 
 ## Handling mismatches
@@ -154,10 +154,10 @@ These post-checksum operations can be done altogether with Fast2, via sequential
 
 ## In practice
 
-Pick the lightest strategy that satisfies your integrity requirement: size comparison costs almost nothing but is the weakest signal; calculating the hash on both ends with Fast2 is the strongest, but reads every content twice. Most projects validate the bulk with a cheap strategy and reserve full hashing for the assets that matter most — or run a 100% hash pass when the compliance bar requires it, accepting the extra I/O.
+Pick the lightest strategy that still satisfies your integrity requirement. Size comparison costs almost nothing, but it's the weakest signal. Hashing on both ends with Fast2 is the strongest, and it reads every content twice. Plenty of projects split the difference: a cheap check across the bulk, full hashing kept for the assets that actually matter. When the compliance bar demands 100% hashing, you do it and you accept the extra I/O.
 
 :::info Related
-- [HashSignTask — Compute content hash](../catalog/tool.md#HashSignTask)
-- [Delta Migration](./delta-migration.md) — reconciliation as part of a catch-up phase
+- [HashSignTask (Compute content hash)](../catalog/tool.md#HashSignTask)
+- [Delta Migration](./delta-migration.md): reconciliation as part of a catch-up phase
 - [Patterns](../advanced/patterns.md) & [Drools](../advanced/drools.md) for conditional routing of mismatches
 :::

--- a/docs/fast2/playbook/delta-migration.md
+++ b/docs/fast2/playbook/delta-migration.md
@@ -12,21 +12,21 @@ content_hash: b7e2be9a329488111b68bdb00ff4d557d5d0aa3ebeff6b092ca3e6ebb7b5bd00
 
 > [See Part 1, Extracting From a Live ECM →](./extracting-from-live-ecm.md)
 
-After bulk extraction, the source has not stopped. Catching up is the second half of the job. You close the gap without losing a single document, audit entry, or ACL change, and then you sign off the cutover against an audit trail a regulator will accept.
+After bulk extraction, the source has not stopped. Catching up is the second half of the job. You have to close the gap without losing a single document, audit entry, or ACL change, and then sign off the cutover against an audit trail a regulator will accept.
 
 :::tip TL;DR
-- Bulk extraction is roughly half the work. The delta capture, the reconciliation, and the cutover are the other half. That second half is where projects fail.
-- Four delta-capture mechanisms cover almost every real situation: CDC, native ECM events, timestamp watermark, source-side flagging. Each has a clear "use when" and a clear "do not use when."
-- Reconciliation is layered. Manifest plus checksum first, destination-side duplicate prevention second, statistical sampling third, business validation last. Skip a layer and you find out months later.
-- Cutover is a decision, not a feature. Big-bang, phased, parallel run, blue-green. Each has a profile. Pick before you start.
-- Fast2 ships the moving parts: incremental sources, per-injector duplicate prevention, SQL back-flagging, dashboards. The watermark store, the circuit breaker, and the sign-off ritual are still the engineer's job.
+- Bulk extraction is roughly half the work. Delta capture, reconciliation, and cutover are the rest, and that's where projects fail.
+- Four delta-capture mechanisms cover almost every real situation: CDC, native ECM events, timestamp watermark, source-side flagging. Each comes with a "use when" and, just as important, a "don't use when."
+- Reconciliation is layered. Manifest plus checksum first, then destination-side duplicate prevention, then statistical sampling, with business validation last. Skip a layer and you'll find out months later.
+- Cutover is a decision you make at the start. Big-bang, phased, parallel run, blue-green: each fits a different situation. Pick before you start.
+- Fast2 ships the moving parts: incremental sources, per-injector duplicate prevention, SQL back-flagging, dashboards. The watermark store, the circuit breaker, and the sign-off ritual are still on you.
 :::
 
 ## The moving target problem
 
-Bulk extraction is comforting because it has a number attached to it. Fourteen weeks, 80M documents, dashboard green. The trouble is that during those fourteen weeks, the source kept producing documents, modifying ACLs, retiring older items, and writing new audit-trail entries. "We'll just re-run extraction at the end" is a decision I have watched blow up a project budget twice. Another fourteen weeks, during which the source has, again, kept moving.
+Bulk extraction is comforting because it has a number attached to it. Fourteen weeks, 80M documents, dashboard green. Trouble is, during those fourteen weeks the source kept producing documents, modifying ACLs, retiring older items, and writing new audit-trail entries. "We'll just re-run extraction at the end" is a decision I've watched blow up a project budget twice. You buy yourself another fourteen weeks, during which the source has, again, kept moving.
 
-What you need instead is a mechanism that captures only what changed since the last known point, replays it, and proves on both sides that nothing was lost. That is the delta phase. It needs its own design and its own go/no-go gate.
+What you actually need is a mechanism that captures only what changed since the last known point, replays it, and proves on both sides that nothing was lost. That's the delta phase. It gets its own design and its own go/no-go gate.
 
 ## The four mechanisms of delta capture
 
@@ -34,71 +34,71 @@ There are really only four ways to know what changed in a source between T and T
 
 ### A. Change Data Capture (CDC): read the transaction log
 
-CDC tools tail the source database's redo or WAL log and emit each row-level change as an event. Debezium is the open-source reference. Oracle GoldenGate, AWS DMS, Striim, and Qlik Replicate are the commercial variants. When it works, it is the cleanest mechanism available: low latency, no polling pressure on the source, no schema modification required.
+CDC tools tail the source database's redo or WAL log and emit each row-level change as an event. Debezium is the open-source reference. Oracle GoldenGate, AWS DMS, Striim, and Qlik Replicate are the commercial variants. When it works, it's the cleanest mechanism you can get: low latency, no polling pressure on the source, and nothing to change in the schema.
 
 ![Change Data Capture, tailing the source database's transaction log and replaying each change against the target via a stream and a checkpoint](../assets/img/playbook/delta-01-cdc.png)
 
-Support terms kill it first. Most enterprise ECMs (Documentum, FileNet, Alfresco Enterprise) treat the underlying database as private and unsupported. Any read of `dm_sysobject` or `DocVersion` outside the vendor's API routinely voids your support contract. On a large share of real ECM migrations, that single clause rules out CDC for the document plane.
+Support terms usually kill it first. Most enterprise ECMs (Documentum, FileNet, Alfresco Enterprise) treat the underlying database as private and unsupported. Any read of `dm_sysobject` or `DocVersion` outside the vendor's API routinely voids your support contract. On a large share of real ECM migrations, that one clause rules out CDC for the document plane.
 
-Throughput is the second wall. Debezium is at-least-once and effectively single-threaded per connector, around 7,000 events per second sustained in well-tuned deployments. For a 4B-document FileNet estate moving at 120M documents per day, that is a hard ceiling you hit on day one.
+Throughput is the second wall. Debezium is at-least-once and effectively single-threaded per connector, around 7,000 events per second sustained in well-tuned deployments. For a 4B-document FileNet estate moving at 120M documents per day, that's a hard ceiling, and you hit it on day one.
 
-Then there is the operational tail. Postgres logical replication slots bloat the WAL if the consumer falls behind. Debezium tracks DDL via an internal schema-history topic and absorbs additive changes (a new nullable column) automatically; breaking changes such as a drop, rename, or type change still require consumer coordination or they quietly break the pipeline. GoldenGate licensing (~$17,500 per processor, plus Veridata for diff) is rarely in the budget envelope.
+Then there's the operational tail. Postgres logical replication slots bloat the WAL if the consumer falls behind. Debezium tracks DDL via an internal schema-history topic and absorbs additive changes (a new nullable column) automatically. Breaking changes such as a drop, rename, or type change still need consumer coordination, or they quietly break the pipeline. And GoldenGate licensing (~$17,500 per processor, plus Veridata for diff) is rarely in the budget envelope.
 
-**Use when:** source is a relational DB you legitimately can read, throughput is below the engine's ceiling, and you have someone on staff who has run Debezium in anger.
-**Avoid when:** ECM vendor forbids DB access, sustained throughput is above ~7k events/s, or the team has never operated a CDC pipeline before.
+**Use when:** the source is a relational DB you can legitimately read, throughput sits below the engine's ceiling, and you've got someone on staff who has run Debezium in anger.
+**Avoid when:** the ECM vendor forbids DB access, sustained throughput is above ~7k events/s, or nobody on the team has operated a CDC pipeline before.
 
 ### B. Native ECM event subscription: let the source tell you
 
-Every serious ECM has an internal event mechanism. FileNet P8 writes to its `Event` table. Documentum has `dmi_queue_item` and event-driven workflows. SharePoint exposes change tokens via Microsoft Graph. Alfresco emits audit events through its public API. You subscribe, you consume, you replay.
+Every serious ECM has an internal event mechanism. FileNet P8 writes to its `Event` table. Documentum has `dmi_queue_item` and event-driven workflows. SharePoint exposes change tokens via Microsoft Graph. Alfresco emits audit events through its public API. You subscribe, consume, and replay.
 
 ![Native ECM event subscription: reading the vendor's own audit feed or change-token API and advancing a pointer on each consumed event](../assets/img/playbook/delta-02-event-subscription.png)
 
-This is the vendor-blessed path. Your support contract stays intact and schema drift is the vendor's problem. There are two real risks. The first is throughput, because event tables are not designed for sustained drain at migration scale. The second is the retention window. If the source's audit retention is 90 days and your migration runs 14 months, the events for the first 11 months are already gone. One project I worked discovered this on month nine, and the fallback to a full timestamp re-scan was painful.
+This is the vendor-blessed path. Your support contract stays intact and schema drift becomes the vendor's problem. Two risks are worth your attention. Throughput, first, because event tables aren't designed for sustained drain at migration scale. Then the retention window. If the source's audit retention is 90 days and your migration runs 14 months, the events for the first 11 months are already gone. One project I worked discovered this on month nine, and the fallback to a full timestamp re-scan was ugly.
 
-**Use when:** vendor forbids DB access, change rate is moderate, audit retention exceeds the migration window plus a healthy buffer.
+**Use when:** the vendor forbids DB access, the change rate is moderate, and audit retention comfortably exceeds the migration window with buffer to spare.
 **Avoid when:** audit retention is shorter than the migration timeline, or the event table is already a performance bottleneck for the application team.
 
 ### C. Watermark / timestamp delta: "give me everything modified since T"
 
-This is the simplest mechanism, and the one most teams reach for first. You run an incremental Fast2 Source whose WHERE clause is `last_modified > :last_run_ts`, you record the high-water mark, you advance the pointer. Fast2 supports the pattern out of the box for SQL-backed sources; for S3 you use `start-after` to the same effect. The Fast2 Loader documentation describes two loading modes: one-shot full load, or incremental load.
+This is the simplest mechanism, and the one most teams reach for first. You run an incremental Fast2 Source whose WHERE clause is `last_modified > :last_run_ts`, record the high-water mark, and advance the pointer. Fast2 supports the pattern out of the box for SQL-backed sources. For S3 you use `start-after` to the same effect. The Fast2 Loader documentation describes two loading modes: one-shot full load, or incremental load.
 
 ![Watermark loop: Fast2 queries for everything modified since the last watermark, then advances the watermark to the highest timestamp seen](../assets/img/playbook/delta-03-watermark-loop.png)
 
-Five pitfalls show up consistently.
+Five pitfalls show up over and over.
 
-1. **Clock skew** is the most common. If the source DB and Fast2 server drift by 200ms (well within NTP tolerance on a default config) you either miss rows at the boundary or duplicate them. Use a logical sequence column when the source offers one. Otherwise overlap windows deliberately and rely on the destination checker for idempotency.
-2. **Soft deletes** are the silent killer. Many ECMs mark a document deleted by flipping a status column without bumping `last_modified`. The delete never shows up on a watermark query, so you need a parallel scan against the deletion flag.
-3. **Bulk re-stamp** turns a delta into a full load. A schema migration, a reindex, a retention sweep. Any of these can touch every row and bump `last_modified` on all of them. Have a kill-switch.
-4. **Boundary precision** is the case the Documentum community has been warning about for years on `r_modify_date`. Subsecond precision lost in transit means `>` becomes `>=` becomes a duplicate. Pick a side and stick to it.
-5. **Late-arriving rows** are the boundary case nobody plans for. Long-running transactions can commit a row whose `last_modified` is older than your watermark by the time you read it. Overlap windows by at least the longest expected transaction duration, and accept that the destination checker will be doing real work.
+1. **Clock skew** is the most common. If the source DB and Fast2 server drift by 200ms (well within NTP tolerance on a default config) you'll either miss rows at the boundary or duplicate them. Use a logical sequence column when the source offers one. If it doesn't, overlap your windows on purpose and lean on the destination checker for idempotency.
+2. **Soft deletes** are the silent killer. Plenty of ECMs mark a document deleted by flipping a status column without bumping `last_modified`. The delete never shows up on a watermark query. You need a parallel scan against the deletion flag.
+3. **Bulk re-stamp** turns a delta back into a full load. A schema migration, a reindex, a retention sweep, any one of these can touch every row and bump `last_modified` on all of them. Have a kill-switch.
+4. **Boundary precision** is the one the Documentum community has been warning about for years on `r_modify_date`. Lose subsecond precision in transit and `>` quietly becomes `>=`, which becomes a duplicate. Pick a side and stick to it.
+5. **Late-arriving rows** are the boundary case nobody plans for. A long-running transaction can commit a row whose `last_modified` is already older than your watermark by the time you read it. Overlap windows by at least the longest expected transaction duration, and accept that the destination checker will be earning its keep.
 
-**Use when:** the source has a trustworthy modified-timestamp column, the change rate is high enough that events are noisy but low enough that you can afford a periodic scan.
+**Use when:** the source has a modified-timestamp column you can trust, and the change rate is high enough that events get noisy but low enough that a periodic scan is affordable.
 **Avoid when:** the source bulk-re-stamps rows for reasons unrelated to user activity (reindex, retention sweep), or when soft deletes are the dominant change type.
 
 ### D. Source-side flagging: write back to the source
 
-When you own the source schema and the regulator does not get in the way, the most reliable mechanism is to write a `migrated_at` property on each source object as you complete it. The delta query becomes "give me everything where `migrated_at IS NULL`". No clocks, no watermarks, no boundary bugs.
+When you own the source schema and no regulator gets in the way, the most reliable mechanism is to write a `migrated_at` property on each source object as you finish it. The delta query becomes "give me everything where `migrated_at IS NULL`". No clocks, no watermarks, no boundary bugs.
 
 ![Source-side flagging: Fast2 stamps each migrated source object with a migrated_at property, so the next query naturally returns only what is left](../assets/img/playbook/delta-04-source-flagging.png)
 
-Fast2 does not ship a productized "Mark as migrated" task, which is the most common misconception about this pattern. What Fast2 ships is `SQLStatementTask` (and its `UpdateSQLQueryTask` variant), which executes an arbitrary parameterised UPDATE in the pipeline. You stamp the source on successful ingest. If the pattern needs to be richer, say a flag plus a retry counter plus an error code, a small custom transformer built against the Maven SDK does the job.
+Fast2 does not ship a productized "Mark as migrated" task. That's the most common misconception about this pattern. What it ships is `SQLStatementTask` (and its `UpdateSQLQueryTask` variant), which executes an arbitrary parameterised UPDATE in the pipeline. You stamp the source on successful ingest. If you need something richer, say a flag plus a retry counter plus an error code, a small custom transformer built against the Maven SDK does the job.
 
 **Use when:** you own the source schema, the source is not a WORM/Centera/regulated archive, and the application team is comfortable with a new column.
-**Avoid when:** source is regulated (21 CFR Part 11, GxP, SOX-relevant archives where any modification triggers an audit event), or the application team explicitly refuses schema changes. In those cases, fall back to watermark plus destination-side reconciliation.
+**Avoid when:** the source is regulated (21 CFR Part 11, GxP, SOX-relevant archives where any modification triggers an audit event), or the application team flatly refuses schema changes. Then fall back to watermark plus destination-side reconciliation.
 
 ## Destination-side reconciliation
 
-Delta capture tells you what should arrive. Reconciliation tells you whether it actually did. Two different problems, and the second is where most teams skimp. In a serious migration, reconciliation is layered. Not a single check.
+Delta capture tells you what should arrive. Reconciliation tells you whether it actually did, and that's where most teams skimp. In a serious migration, reconciliation is layered, never a single check.
 
 ### Layer 1: Manifest + checksum
 
 Every Fast2 batch (every punnet) produces a manifest: source object ID, SHA-256 of the binary, byte size, source timestamp, target ID, target timestamp. The target verifies on ingest. At sign-off, the manifest is compared row-by-row against both the source inventory and the target inventory. Three-way match or no sign-off.
 
-The case study worth knowing is Fast2's own published insurer migration onto Alfresco. MD5 hash validation on every document, combined with counter cross-referencing, produced an auditable completeness report. The false-positive risk is real. If you legitimately transform the binary in transit (PDF/A normalization, image recompression), the source hash will not match the target hash. Compute and store both, or compute on a canonical form.
+The case study worth knowing is Fast2's own published insurer migration onto Alfresco. MD5 hash validation on every document, combined with counter cross-referencing, produced an auditable completeness report. Watch out for false positives, though. If you transform the binary in transit (PDF/A normalization, image recompression), the source hash won't match the target hash. Compute and store both, or compute on a canonical form.
 
 ### Layer 2: Destination checker (Fast2's per-injector duplicate prevention)
 
-Every Fast2 injector has at least one boolean that turns the target itself into a check. The pattern is consistent across the catalogue:
+Every Fast2 injector has at least one boolean that turns the target itself into a check. The same pattern runs across the catalogue:
 
 | Injector | Setting | Behaviour |
 |---|---|---|
@@ -107,39 +107,39 @@ Every Fast2 injector has at least one boolean that turns the target itself into 
 | FileNetInjector | **Prevent document overwriting** + **Throw exception if document already exists** | WHERE-clause pre-check; configurable strict mode |
 | AwsInjector | **Update only** | Metadata-only update, content untouched |
 
-Underneath, the pattern is always the same. A WHERE-clause lookup against the target before the write, with configurable behaviour on hit (skip, update, overwrite, error). This is what makes a delta phase replayable. When your delta run partially fails and you re-run from a known watermark, the destination checker (Fast2's per-injector duplicate prevention) silently absorbs the duplicates that would otherwise corrupt the target.
+Underneath, it's always the same thing: a WHERE-clause lookup against the target before the write, with configurable behaviour on a hit (skip, update, overwrite, error). This is what makes a delta phase replayable. When a delta run partially fails and you re-run it from a known watermark, the destination checker (Fast2's per-injector duplicate prevention) silently absorbs the duplicates that would otherwise corrupt the target.
 
 ![Destination checker: Fast2 looks up the target before every write, and on a hit the configured mode decides between skip, update, overwrite, or error](../assets/img/playbook/delta-05-destination-checker.png)
 
 ### Layer 3: Statistical sample audit
 
-Counters and hashes prove arithmetic, not fidelity. The third layer is a stratified random sample (typically 0.1% to 1% depending on regulator appetite, stratified by document class) fully rehydrated on the target: open the PDF, OCR a page, compare to the source rendering, check the ACL, check the metadata. Slow, manual or semi-manual work. Non-negotiable for regulated industries.
+Counters and hashes prove arithmetic, not fidelity. The third layer is a stratified random sample (typically 0.1% to 1% depending on regulator appetite, stratified by document class) fully rehydrated on the target: open the PDF, OCR a page, compare to the source rendering, check the ACL, check the metadata. It's slow, manual or semi-manual work. For regulated industries it's non-negotiable.
 
 ### Layer 4: Business validation
 
-The only check that catches semantic loss. A contract whose amendment link is broken, or a retention class silently demoted from "permanent" to "10 years". Neither of these fails any of the previous three layers. They only fail when a data steward, a security officer, and (for financial archives) a CFO open the target through their normal application. Schedule it, and budget for it. The Ameritas migration of 670M Documentum documents to CARA on AWS treats this as a deliverable, not an afterthought.
+This is the only check that catches semantic loss. A contract whose amendment link is broken. A retention class silently demoted from "permanent" to "10 years". Neither of those trips any of the previous three layers. They surface only when a data steward, a security officer, and (for financial archives) a CFO open the target through their normal application. Schedule it, and budget for it. The Ameritas migration of 670M Documentum documents to CARA on AWS treats this as a deliverable, not an afterthought.
 
 ## Cutover patterns
 
-The mechanism is delta. The moment is cutover. You need to pick a cutover pattern at the start of the project, not at the end.
+Delta is the mechanism. Cutover is the moment it all becomes real. Pick your cutover pattern at the start of the project, not at the end.
 
 | Pattern | When to use | Main risk | Reference |
 |---|---|---|---|
 | Big-bang freeze + final delta | Small estate (under 10M docs), tolerable freeze window, simple source | Discovering defects under load | TSB Bank, Big Bang cutover, multi-week incident, £330M+ remediation |
 | Progressive / phased | Large estate, multiple business units, can tolerate temporary heterogeneity | Long total duration; reconciliation per phase | Microsoft SPMT phased migration patterns |
-| Parallel run / dual-write | Cannot tolerate any read-side outage, application can route reads to either side | Application changes (strangler fig); doubled write cost during the window | Common in insurance core systems; 72–96h read-side validation typical |
+| Parallel run / dual-write | Cannot tolerate any read-side outage, application can route reads to either side | Application changes (strangler fig); doubled write cost during the window | Common in insurance core systems; 72 to 96h read-side validation typical |
 | Blue-green DB flip | Source is a database you control end-to-end, RTO measured in minutes | No auto-fallback after switchover | AWS RDS Blue/Green docs, "no automated failback" |
 | Trickle with read-redirect | Very large estate, no acceptable freeze window | Application complexity (read-router); two truths exist simultaneously | Microsoft SPMT "initial migration + delta sync" pattern |
 
 ![Cutover sequence across Users, Source ECM, Fast2, and Target ECM in three phases: steady-state bulk extraction, delta phase with the source still live, and cutover window with writes frozen on the source and traffic flipped to the target](../assets/img/playbook/delta-06-cutover-swimlane.png)
 
-Cutover is not where you find defects. It is where you prove there are none left. The TSB case is the cautionary tale of the decade. 5.2 million customers cut over in a single weekend, up to 1.9 million of them locked out of digital banking in an incident that ran for weeks, £330M+ in remediation, and CEO Paul Pester's "the bank is on its knees" Treasury Select Committee testimony now on the public record. The headline finding for practitioners was simple: cutover was the first time the team operated the system at production scale.
+Cutover is the day you prove there are no defects left, not the day you go hunting for them. The TSB case is the cautionary tale of the decade. 5.2 million customers cut over in a single weekend, up to 1.9 million of them locked out of digital banking in an incident that ran for weeks, £330M+ in remediation, and CEO Paul Pester's "the bank is on its knees" Treasury Select Committee testimony now on the public record. The lesson for practitioners is blunt: cutover was the first time the team ran the system at production scale.
 
-Deutsche Bank's Postbank integration on the Magellan platform is the slow-burn variant. Thirteen years, over €1 billion, a 2023 migration-wave outage that ran for days, and a BaFin reprimand. Both projects skipped the same gates.
+Deutsche Bank's Postbank integration on the Magellan platform is the slow-burn version of the same story. Thirteen years, over €1 billion, a 2023 migration-wave outage that ran for days, and a BaFin reprimand. Both projects skipped the same gates.
 
 ## Failure modes that wreck delta phases
 
-The same handful of failures show up on every project.
+The same handful of failures turn up on project after project.
 
 | Failure mode | What it looks like | One-line fix |
 |---|---|---|
@@ -158,28 +158,28 @@ The same handful of failures show up on every project.
 
 ## The Fast2 delta toolbox
 
-What Fast2 actually does for you in a delta phase, and what you still have to build.
+Here's what Fast2 actually does for you in a delta phase, and what you're still on the hook to build.
 
 **What Fast2 ships:**
 
 - **Incremental Source.** WHERE-clause-driven, with full and incremental load modes documented in the Fast2 Loader reference. The Uxopian FAQ frames it for the business: "incremental, or delta, migrations let users keep working while data moves in the background."
 - **Per-injector duplicate prevention.** Alfresco "Prevent duplicate," FileNet "Prevent document overwriting," AwsInjector "Update only," Alfresco REST "Safe update" / "Auto rename." A WHERE-clause lookup before write, configurable on hit.
-- **SQLStatementTask / UpdateSQLQueryTask** are the building block for back-flagging the source without writing custom code.
+- **SQLStatementTask / UpdateSQLQueryTask** are your building block for back-flagging the source without writing custom code.
 - **Dashboards backed by Elasticsearch and Kibana.** Live counters, per-document trace IDs, ingestion rate, error breakdown. Enough to run an operations room.
-- **Maven SDK** is the escape hatch. Custom Sources, Transformers, Injectors, Tasks for the things Fast2 cannot do out of the box on your specific source.
+- **Maven SDK** is the escape hatch. Custom Sources, Transformers, Injectors, and Tasks for whatever Fast2 can't do out of the box on your specific source.
 
-**What Fast2 does not ship, and you should not pretend it does:**
+**What Fast2 does not ship, and you shouldn't pretend it does:**
 
-- *A built-in watermark or checkpoint store.* The pattern is supported, but the storage and the advance-the-pointer logic are the engineer's responsibility. A small Postgres table or a JSON file in a known path is what most projects end up with.
-- *A productized "Mark as migrated" task.* You build it from `SQLStatementTask` or a custom transformer in about 30 minutes. Not a checkbox feature.
-- *A circuit breaker for the source.* If your watermark query suddenly returns 100x the expected volume because someone ran a reindex, Fast2 will faithfully try to ingest 100x the expected volume. You build the volume anomaly check around it.
-- *A platform-wide idempotency flag.* Idempotency comes from unique punnet IDs combined with the per-injector duplicate-prevention booleans. It works. But it is a pattern, not a single switch.
+- *A built-in watermark or checkpoint store.* The pattern is supported, but the storage and the advance-the-pointer logic are on you. Most projects end up with a small Postgres table or a JSON file in a known path.
+- *A productized "Mark as migrated" task.* You build it from `SQLStatementTask` or a custom transformer in about 30 minutes. Not a checkbox.
+- *A circuit breaker for the source.* If your watermark query suddenly returns 100x the expected volume because someone ran a reindex, Fast2 will faithfully try to ingest 100x the expected volume. The volume anomaly check is yours to build around it.
+- *A platform-wide idempotency flag.* Idempotency comes from unique punnet IDs combined with the per-injector duplicate-prevention booleans. It works, but it's a pattern you assemble, not a single switch.
 
-Pre-sales decks sometimes treat "incremental migration" as a feature checkbox. In real projects it is a methodology you build on top of three Fast2 features and one custom module. The customer should know this before contract signature, not in week six of delivery.
+Pre-sales decks sometimes treat "incremental migration" as a feature checkbox. On a real project it's a methodology you build on top of three Fast2 features and one custom module. The customer needs to know that before contract signature, not in week six of delivery.
 
 ## Sign-off ritual
 
-Sign-off is a ritual in the literal sense. A sequence of steps performed in front of named witnesses, with named artefacts, before the source is allowed to go read-only. For every batch, and for the final cutover, three rows on the sign-off sheet:
+Sign-off is a ritual in the literal sense: a fixed sequence of steps, performed in front of named witnesses with named artefacts, before the source is ever allowed to go read-only. For every batch, and again for the final cutover, three rows on the sign-off sheet:
 
 | Row | What it proves | Evidence | Sign-off owner |
 |---|---|---|---|
@@ -187,8 +187,8 @@ Sign-off is a ritual in the literal sense. A sequence of steps performed in fron
 | Fidelity | Documents are intact and readable | Statistical sample audit, fully rehydrated, signed report | QA lead |
 | Business validation | Semantics preserved | Data steward walkthrough on real business cases; for finance, CFO signature on aggregate totals | Business owner |
 
-For regulated industries, add the framework relevant to the estate (GxP, 21 CFR Part 11, EU Annex 11, SOX, HIPAA, GDPR) and an explicit cross-reference to the regulator-facing audit trail. Generis markets CARA's coverage of these frameworks, which is a reasonable reference point. Hopp Tech and Datafold both publish sign-off threshold templates; either is a baseline to adapt rather than starting from a blank page.
+For regulated industries, add the framework relevant to the estate (GxP, 21 CFR Part 11, EU Annex 11, SOX, HIPAA, GDPR) and an explicit cross-reference to the regulator-facing audit trail. Generis markets CARA's coverage of these frameworks, which is a reasonable reference point. Hopp Tech and Datafold both publish sign-off threshold templates. Either gives you a baseline to adapt instead of starting from a blank page.
 
 The threshold matters as much as the procedure. "99.5% match" is not a sign-off if the missing 0.5% is the legal archive. Define the threshold per document class, agree it in writing with the business owner before the delta phase begins, and for the regulated classes treat the threshold as zero.
 
-Before you start any of the design work, settle one question with the business owner. Which of the four delta mechanisms is permitted on this source. Everything else in this article follows from that answer.
+Before any of the design work, settle one question with the business owner: which of the four delta mechanisms is permitted on this source. Everything else in this article follows from that answer.

--- a/docs/fast2/playbook/deployment-variants.md
+++ b/docs/fast2/playbook/deployment-variants.md
@@ -14,20 +14,20 @@ content_hash: e0f8947b653cc2ae381c1409f4b9fe94761d279d324081ff9eb3d5a70e88e212
 <img src="/img/fast2-playbook/deployment-cover.png" alt="Fast2 deployment topology: a source ECM feeding Fast2 workers across on-premise and cloud, converging on the target ECM" width="820" />
 </div>
 
-Where you run Fast2 relative to the source and target systems is an architecture decision you make before the first campaign, and it shapes everything that follows: how much data leaves the building, how fast you go, and how hard the project is to debug. Fast2 supports four deployment shapes for a content-migration project. This article walks each one through the same three lenses — access control, performance, and debugging — using a FileNet-to-AWS-S3 migration as the running example.
+Decide where Fast2 sits relative to the source and target before you launch the first campaign. That one choice drives how much data leaves the building, how fast you go, and how painful it'll be to debug when something breaks. Fast2 runs in four deployment shapes for a content migration. This article walks each one through the same three lenses (access control, performance, debugging) with a FileNet-to-AWS-S3 migration as the running example.
 
-## Option 1 — On-premise
+## Option 1: On-premise
 
-Fast2 runs inside the customer's own network, alongside the source ECM. This is the most private option: the only traffic that leaves the perimeter is the connection to the destination, which in the FileNet-to-S3 example is the S3 link, already protected by AWS encryption in transit and at rest.
+Fast2 runs inside the customer's own network, right next to the source ECM. This is the most private option. The only traffic that leaves the perimeter is the connection out to the destination, which in the FileNet-to-S3 example is the S3 link, already protected by AWS encryption in transit and at rest.
 
-### Sub-option A — Same machine
+### Sub-option A: Same machine
 
 <div style={{display:'flex',gap:'2rem',alignItems:'center',flexWrap:'wrap',margin:'1.5rem 0'}}>
 <div style={{flex:'1 1 320px',minWidth:'300px'}}>
 
-Fast2 is installed directly on the ECM server. The source is reached over localhost, so nothing about the document plane touches the network at all. The single external channel is the S3 connection.
+Fast2 sits directly on the ECM server. The source is reached over localhost, so nothing on the document plane touches the network at all. The one external channel is the S3 connection.
 
-This is maximally private, but Fast2 and the ECM now compete for the same CPU, memory, and I/O. On a busy production source that contention is exactly what you are trying to avoid (see [Extracting From a Live ECM](./extracting-from-live-ecm.md)). Reserve it for clones, staging copies, or sources with headroom to spare.
+You can't get more private than that. The catch: Fast2 and the ECM now fight over the same CPU, memory, and I/O. On a busy production source that contention is the exact thing you're trying to avoid (see [Extracting From a Live ECM](./extracting-from-live-ecm.md)). Keep this one for clones, staging copies, or sources with headroom to spare.
 
 </div>
 <div style={{flex:'1 1 380px',minWidth:'300px',textAlign:'center'}}>
@@ -37,7 +37,7 @@ This is maximally private, but Fast2 and the ECM now compete for the same CPU, m
 </div>
 </div>
 
-### Sub-option B — Same network
+### Sub-option B: Same network
 
 <div style={{display:'flex',gap:'2rem',alignItems:'center',flexWrap:'wrap',margin:'1.5rem 0'}}>
 <div style={{flex:'1 1 380px',minWidth:'300px',textAlign:'center'}}>
@@ -47,21 +47,21 @@ This is maximally private, but Fast2 and the ECM now compete for the same CPU, m
 </div>
 <div style={{flex:'1 1 320px',minWidth:'300px'}}>
 
-Fast2 is installed on a separate server inside the enterprise network. You keep the privacy benefits of staying on-premise while isolating the migration workload from the ECM's own resources, which prevents resource contention and improves stability.
+Fast2 sits on a separate server inside the enterprise network. You keep the privacy of staying on-premise, but the migration workload no longer steals the ECM's resources, so you avoid the contention and the source stays stable.
 
 This is the on-premise default. Same trust boundary, no resource fight.
 
 </div>
 </div>
 
-## Option 2 — Cloud-based
+## Option 2: Cloud-based
 
 <div style={{display:'flex',gap:'2rem',alignItems:'center',flexWrap:'wrap',margin:'1.5rem 0'}}>
 <div style={{flex:'1 1 320px',minWidth:'300px'}}>
 
-Fast2 runs remotely, in the cloud. This cuts infrastructure cost and makes it trivial to scale workers up and down on demand. The trade-off is exposure: you have to open remote access from the cloud into both the source and the destination, which can raise confidentiality concerns and usually means VPN, peering, or firewall changes that the customer's security team has to approve.
+Fast2 runs remotely, in the cloud. Infrastructure cost drops, and scaling workers up and down on demand becomes trivial. What you give up is exposure. You have to open remote access from the cloud into both the source and the destination. That raises confidentiality questions, and it usually means VPN, peering, or firewall changes that the customer's security team has to sign off on.
 
-Best when the source is itself cloud-hosted, or when the customer is comfortable opening controlled access and wants elastic scale.
+Best when the source is already cloud-hosted, or when the customer is fine opening controlled access and wants elastic scale.
 
 </div>
 <div style={{flex:'1 1 380px',minWidth:'300px',textAlign:'center'}}>
@@ -71,7 +71,7 @@ Best when the source is itself cloud-hosted, or when the customer is comfortable
 </div>
 </div>
 
-## Option 3 — Hybrid
+## Option 3: Hybrid
 
 <div style={{display:'flex',gap:'2rem',alignItems:'center',flexWrap:'wrap',margin:'1.5rem 0'}}>
 <div style={{flex:'1 1 380px',minWidth:'300px',textAlign:'center'}}>
@@ -81,21 +81,21 @@ Best when the source is itself cloud-hosted, or when the customer is comfortable
 </div>
 <div style={{flex:'1 1 320px',minWidth:'300px'}}>
 
-The broker runs remotely while the workers run on-premise, next to the ECM. Sensitive document traffic stays internal — the workers read from the source locally — while the lightweight orchestration and queueing happen in the cloud. This balances the performance and scale of a cloud broker against the security of keeping the heavy, confidential data path inside the network.
+The broker runs remotely while the workers run on-premise, next to the ECM. Sensitive document traffic never leaves the building, since the workers read from the source locally, while the lightweight orchestration and queueing happen in the cloud. So you get the scale of a cloud broker without pushing the heavy, confidential data path out over the wire.
 
-The cost is operational complexity. With components split across two environments, debugging is harder: a failure could be in the cloud broker, the on-premise worker, or the link between them. Useful detail when planning: it is fairly easy to move to the hybrid architecture *from* either the "same network" on-premise or the fully remote cloud configuration, so you can start simpler and graduate to hybrid if you need to.
+What it costs you is operational complexity. With components split across two environments, debugging gets harder. A failure could be in the cloud broker, in the on-premise worker, or in the link between them, and you have to figure out which. One useful planning detail: moving *to* hybrid from either the "same network" on-premise setup or the fully remote cloud setup is fairly painless, so you can start simpler and graduate to hybrid later if you need to.
 
 </div>
 </div>
 
-## Option 4 — AWS Snowball
+## Option 4: AWS Snowball
 
 <div style={{display:'flex',gap:'2rem',alignItems:'center',flexWrap:'wrap',margin:'1.5rem 0'}}>
 <div style={{flex:'1 1 320px',minWidth:'300px'}}>
 
-For very large estates or constrained bandwidth, data is transferred locally onto a physical AWS Snowball device, which is then shipped to AWS and loaded into S3. This preserves bandwidth and keeps the data confidential in transit (the device is encrypted and physically moved rather than streamed over the wire).
+For very large estates, or when bandwidth is tight, you write the data locally onto a physical AWS Snowball device, ship the device to AWS, and load it into S3 there. It saves your bandwidth and keeps the data confidential in transit, since the device is encrypted and physically moved rather than streamed over the wire.
 
-The trade-offs are physical: shipping introduces real-world delay, and scalability is limited by device capacity and the logistics of moving drives. Best for one-shot bulk seeding of a huge archive where the network would otherwise be the bottleneck.
+The trade-offs here are physical. Shipping a box introduces real-world delay, and you're capped by device capacity and the logistics of moving drives around. Best for a one-shot bulk seed of a huge archive where the network would otherwise be the bottleneck.
 
 </div>
 <div style={{flex:'1 1 380px',minWidth:'300px',textAlign:'center'}}>
@@ -109,11 +109,11 @@ The trade-offs are physical: shipping introduces real-world delay, and scalabili
 
 | Factor | On-prem | Cloud | Hybrid | Snowball |
 |---|---|---|---|---|
-| **Access control** | ✅ | ❌ | ✅ | — |
+| **Access control** | ✅ | ❌ | ✅ | N/A |
 | **Performance** | Mixed | ✅ | ✅ | ✅ |
 | **Debugging** | ✅ | ✅ | ❌ | ✅ |
 | **Scalability** | ❌ | ✅ | ✅ | ❌ |
 
 ## Key takeaway
 
-There is no single right answer; the right shape depends on the customer's confidentiality requirements, available bandwidth, and appetite for operational complexity. One practical note worth remembering: it is pretty easy to switch from both the "same network" and the "remote" configurations to the hybrid architecture, so you are not locked in by your first choice.
+There's no single right answer. The right shape comes down to how strict the customer is about confidentiality, how much bandwidth they have, and how much operational complexity they're willing to live with. And remember: switching to the hybrid architecture from either the "same network" or the "remote" setup is pretty easy, so your first choice doesn't lock you in.

--- a/docs/fast2/playbook/extracting-from-live-ecm.md
+++ b/docs/fast2/playbook/extracting-from-live-ecm.md
@@ -13,22 +13,22 @@ content_hash: 7958316fcc923912d0563076f708c8f04f18cc804e8f7d173e7dc7b8035e509e
 *Part 1 of 2. This article covers bulk extraction against a source that users are still hitting every minute. [Part 2: Delta Migration Methodology →](./delta-migration.md) covers how the target catches up before cutover.*
 
 :::tip TL;DR
-The hard problem in any ECM migration isn't moving the documents. It's moving them while the source is still in production. Three methodologies handle this, in decreasing order of safety: Clone & Sweep, Snapshot & Drip, and Live Trickle. Pick one before you write a single extraction task. Snapshot & Drip is what I reach for on most engagements, because it gives you a stable read surface, predictable throughput, and a clean line between history and delta that makes Part 2 tractable. Plan around 50 to 100 documents per second per extraction thread for an API-bound source, a field-measured benchmark across FileNet, Documentum, and CMIS sources, consistent with the order of magnitude in TSG's published multi-billion-document FileNet case study. Get this wrong and you end up with something like TSB Bank in 2018: roughly £330M in remediation, the CEO out, and the CIO personally sanctioned by the PRA.
+Moving the documents is the easy part. Moving them while the source is still serving production traffic is where migrations go sideways. Three methodologies handle it, from safest to riskiest: Clone & Sweep, Snapshot & Drip, and Live Trickle. Pick one before you write a single extraction task. On most engagements I reach for Snapshot & Drip. It gives you a stable read surface, throughput you can predict, and a clean line between history and delta that makes Part 2 tractable. For an API-bound source, plan around 50 to 100 documents per second per extraction thread. That's a field-measured benchmark across FileNet, Documentum, and CMIS sources, and it sits at the same order of magnitude as TSG's published multi-billion-document FileNet case study. Get this wrong and you end up like TSB Bank in 2018: roughly £330M in remediation, the CEO out, and the CIO personally sanctioned by the PRA.
 :::
 
 ## The problem in one paragraph
 
-Every migration deck shows the same arrow: old box on the left, new box on the right, "Fast2" in the middle. What the deck never shows is the third box behind the old one. Branch managers, claims adjusters, call-centre agents, nurses, all still opening documents in the source system while your extraction job hammers the same database. TSB Bank's 2018 cutover is the canonical reminder. Up to 1.9 million of its 5.2 million customers were locked out of digital banking, roughly £330M in remediation, a £48.65M fine from the FCA and PRA, and a PRA Final Notice in April 2023 imposing a personal sanction of £81,620 on the former CIO. Slaughter and May's independent review pointed to poor migration-team access to the source system among the root causes. Everything in this article is built around not repeating that failure mode.
+Every migration deck shows the same arrow: old box on the left, new box on the right, "Fast2" in the middle. The deck never shows the third box behind the old one. Branch managers, claims adjusters, call-centre agents, nurses. All of them still opening documents in the source system while your extraction job hammers the same database. TSB Bank's 2018 cutover is the reminder everyone cites. Up to 1.9 million of its 5.2 million customers were locked out of digital banking. Roughly £330M in remediation. A £48.65M fine from the FCA and PRA. And a PRA Final Notice in April 2023 imposing a personal sanction of £81,620 on the former CIO. Slaughter and May's independent review named poor migration-team access to the source system among the root causes. Everything here is built around not repeating that.
 
 ## Load surfaces
 
-Before you pick a methodology, picture what the source ECM actually feels when you point an extractor at it. There are three load surfaces, and you hit all of them at the same time.
+Before you pick a methodology, picture what the source ECM actually feels when you point an extractor at it. There are three load surfaces, and you hit all of them at once.
 
 - **The application API.** `IDocument.fetch()` in P8, `DfDocument.getObject()` in Documentum, the CMIS endpoint in Alfresco. Each call burns a session, a thread on the application server, a connection in the pool. Concurrency caps usually sit at 30 to 60 sessions per node. Cross that and the queue forms behind your users, not behind you.
 - **The metadata database.** Oracle, SQL Server, DB2. Your scan pass is a long `SELECT ... WHERE created_at < :high_watermark ORDER BY id`. Without an index hint, you get a full table scan competing for buffer cache with the OLTP queries the business is running.
 - **The blob store.** NAS, IBM TSM, Centera, S3-compatible object store. This is where the volume lives. Naive parallel reads saturate the NIC on the NAS head before anything else gives way. A 10 GbE link can flatline under eight extraction threads pulling 4 MB TIFFs.
 
-When all three surfaces are touched simultaneously by an extractor and by end users, end-user latency degrades before any infrastructure alarm fires. The retrospectives are consistent on the failure pattern: API-only extraction against a live source is unsustainable at scale, and load testing that only happens at cutover is too late to course-correct (ArgonDigital's ECM migration lessons-learned series).
+Hit all three surfaces at the same time, with the extractor and end users competing, and user-facing latency degrades well before any infrastructure alarm fires. The retrospectives agree on the failure pattern: API-only extraction against a live source doesn't hold up at scale, and load testing you only run at cutover lands too late to fix anything (ArgonDigital's ECM migration lessons-learned series).
 
 ---
 
@@ -40,7 +40,7 @@ You stand up a full copy of the source environment, application servers, databas
 
 ![Clone & Sweep: Fast2 extracts from a clone of the source environment, production untouched](../assets/img/playbook/01-clone-and-sweep.png)
 
-Pros: zero production impact, full freedom on threading and parallelism, and the migration team can break things in the clone without consequence. Cons: cost. You pay for a second environment for months. Stand-up effort is non-trivial too. A P8 farm with TSM, Verity, and a 200 TB FileStore is not a one-week task. And then there is drift, which starts the moment you take the clone.
+Upside: zero production impact, full freedom on threading and parallelism, and a sandbox the migration team can break without consequence. Downside: cost. You pay for a second environment for months. Standing it up isn't cheap on effort either. A P8 farm with TSM, Verity, and a 200 TB FileStore is not a one-week job. And then there's drift, which starts the moment you take the clone.
 
 > **When to use:** regulated industries where source-side downtime is contractually forbidden. Banking core, hospital EMR, public-sector citizen services. The Ameritas migration of 670M documents from Documentum to CARA on AWS used this shape. The 50 to 100 docs/sec/thread anchor below is consistent with TSG's published billion-document FileNet engagement and with anonymised field measurements on comparable clone deployments.
 >
@@ -48,16 +48,16 @@ Pros: zero production impact, full freedom on threading and parallelism, and the
 
 ### B. Snapshot & Drip (the default)
 
-Snapshot & Drip is the default choice for most engagements. You take a point-in-time snapshot of the source: a storage snapshot of the blob store (NAS, S3 versioning, Snowball if you are crossing clouds) plus a logical export of the metadata database (`expdp` for Oracle, `bcp` or `BACPAC` for SQL Server, `db2move` for DB2) into a staging zone. Fast2 reads only from the staging zone. Production never feels the extractor.
+This is my default on most engagements. You take a point-in-time snapshot of the source: a storage snapshot of the blob store (NAS, S3 versioning, Snowball if you're crossing clouds) plus a logical export of the metadata database (`expdp` for Oracle, `bcp` or `BACPAC` for SQL Server, `db2move` for DB2) into a staging zone. Fast2 reads only from the staging zone. Production never feels the extractor.
 
 ![Snapshot & Drip: bulk dump into a staging zone, Fast2 reads only the dump, never the live source](../assets/img/playbook/02-snapshot-and-drip.png)
 
-The pattern maps cleanly onto Fast2's two-stage extraction model. The Source task scans the metadata dump (single-threaded, cheap, deterministic). It emits *punnets* (Fast2's term for a pivot XML record carrying document identity, metadata, ACLs, and a blob pointer) into the broker queue. ContentSource workers, scaled horizontally across machines through queue routing, pull punnets and fetch the actual bytes from the blob snapshot. You can run twenty ContentSource threads against a snapshot without anyone in production noticing.
+The pattern maps cleanly onto Fast2's two-stage extraction model. The Source task scans the metadata dump, which is single-threaded, cheap, and deterministic. It emits *punnets* (Fast2's term for a pivot XML record carrying document identity, metadata, ACLs, and a blob pointer) into the broker queue. ContentSource workers, scaled horizontally across machines through queue routing, pull punnets and fetch the actual bytes from the blob snapshot. You can run twenty ContentSource threads against a snapshot and nobody in production will notice.
 
-Three properties make this the right default:
+Why it earns the default slot:
 
-1. **Stable read surface.** The snapshot doesn't change under you. Restarts resume from the last committed punnet ID in the broker queue, so an interrupted campaign re-scans only the tail. No clock skew, no soft-delete edge cases, no "did the document still exist when I read it?" questions.
-2. **Decoupled throughput.** You can saturate the staging zone. That's what it is there for. The 50 to 100 docs/sec/thread figure that haunts API-bound extraction becomes a floor rather than a ceiling. Maretha's FileNet-to-Nuxeo work sustained 120M+ documents per day across two consecutive migrations of 1.4B and 1.6B documents. Hash-keyed blobs travelled by Snowball; metadata streamed through Kafka into Nuxeo Stream (Maretha / Nuxeo case study, 2022).
+1. **Stable read surface.** The snapshot doesn't change under you. Restarts resume from the last committed punnet ID in the broker queue, so an interrupted campaign re-scans only the tail. No clock skew. No soft-delete edge cases. None of the "did this document still exist when I read it?" questions that eat your afternoon.
+2. **Decoupled throughput.** Saturate the staging zone. That's what it's there for. The 50-to-100 docs/sec/thread figure that haunts API-bound extraction turns into a floor instead of a ceiling. Maretha's FileNet-to-Nuxeo work sustained 120M+ documents per day across two consecutive migrations of 1.4B and 1.6B documents. Hash-keyed blobs travelled by Snowball; metadata streamed through Kafka into Nuxeo Stream (Maretha / Nuxeo case study, 2022).
 3. **Clean separation of history and delta.** Everything in the snapshot is history. Anything created in the source after snapshot time is delta. That boundary is what makes the delta phase in Part 2 tractable.
 
 > **When to use:** as your default. Any volume above ~10M documents, any source you don't fully control, any project with a sponsor exposed to the TSB-style regulatory tail.
@@ -70,7 +70,7 @@ The fallback. Direct extraction from the production source, with aggressive thro
 
 ![Live Trickle: direct extraction from production with throttling, kill switch, and a trip threshold from prod monitoring](../assets/img/playbook/03-live-trickle.png)
 
-Live Trickle is what you do when neither A nor B is on the table, usually because the customer's infrastructure team cannot or will not provision the storage and compute for a clone or staging zone, and the calendar won't wait. It works. But every operational lever has to be set conservatively and reviewed weekly. You will be slower, you will be more careful, and you will spend more time in change-control meetings than you expected.
+Live Trickle is what you do when neither A nor B is on the table. Usually that's because the customer's infrastructure team can't or won't provision the storage and compute for a clone or staging zone, and the calendar won't wait. It works. But every operational lever has to sit conservative and get reviewed weekly. You'll be slower. You'll be more careful. And you'll spend more time in change-control meetings than you planned for.
 
 > **When to use:** small-to-medium volumes (low millions), sources with mature concurrency governance (Oracle Resource Manager, SQL Server Resource Governor) you can lean on, and tight operational coupling with the source team.
 >
@@ -82,27 +82,27 @@ Live Trickle is what you do when neither A nor B is on the table, usually becaus
 
 | Scenario | Volume | User pressure | Recommended methodology |
 |---|---|---|---|
-| Regulated retail bank, core records | 100M–1B+ | 24/7, regulator on your back | **A. Clone & Sweep** |
-| National health insurer, claims archive | 500M–4B | Office hours, weekend windows OK | **B. Snapshot & Drip** |
-| Hospital EMR, active patient records | 10M–100M | Strict 24/7, life-critical | **A. Clone & Sweep** |
-| Public sector, multi-agency consolidation | 50M–500M | Office hours | **B. Snapshot & Drip** |
-| Insurance back-office, legacy P8 to cloud ECM | 100M–1B | Business hours | **B. Snapshot & Drip** |
-| Pharma / life sciences, audit-traceable | 1M–50M | Business hours | **A or B**, depending on validation rules |
-| Mid-market manufacturer, internal users | 1M–10M | Office hours, flexible | **C. Live Trickle**, with off-peak windows |
+| Regulated retail bank, core records | 100M to 1B+ | 24/7, regulator on your back | **A. Clone & Sweep** |
+| National health insurer, claims archive | 500M to 4B | Office hours, weekend windows OK | **B. Snapshot & Drip** |
+| Hospital EMR, active patient records | 10M to 100M | Strict 24/7, life-critical | **A. Clone & Sweep** |
+| Public sector, multi-agency consolidation | 50M to 500M | Office hours | **B. Snapshot & Drip** |
+| Insurance back-office, legacy P8 to cloud ECM | 100M to 1B | Business hours | **B. Snapshot & Drip** |
+| Pharma / life sciences, audit-traceable | 1M to 50M | Business hours | **A or B**, depending on validation rules |
+| Mid-market manufacturer, internal users | 1M to 10M | Office hours, flexible | **C. Live Trickle**, with off-peak windows |
 | Multi-region archive, no live consumers | Any | None | **B. Snapshot & Drip** (or direct dump to Fast2) |
 
-A useful gut-check: if the sponsor cannot tolerate any measurable degradation in source response time during business hours, you are in column A. If they can tolerate it during a Saturday night window, you are in column B. If they shrug, you might get away with column C.
+A useful gut-check. If the sponsor can't tolerate any measurable degradation in source response time during business hours, you're in column A. If they can live with it during a Saturday-night window, you're in column B. If they shrug, you might get away with column C.
 
 ---
 
 ## Throttling and governance: the controls that matter
 
-Whichever methodology you pick, the same set of Fast2 levers determines whether your extraction stays inside the envelope you negotiated. What matters is choosing values that match the load surface you're actually hitting.
+Whichever methodology you pick, the same Fast2 levers decide whether your extraction stays inside the envelope you negotiated. The trick is picking values that match the load surface you're actually hitting, not the one in the sizing spreadsheet.
 
 | Fast2 lever | What it controls | Practical guidance |
 |---|---|---|
-| **Threads per task** | Concurrency inside a single worker | Start low (4–8) on Source tasks. ContentSource can usually go higher (16–32) if reading from a snapshot. Halve it if you are hitting prod. |
-| **Batch / page size** | Records fetched per API round-trip | Match to source page-size sweet spot. P8 likes 100–500; CMIS likes 50–200. Bigger pages reduce round-trip overhead but increase per-call memory. |
+| **Threads per task** | Concurrency inside a single worker | Start low (4 to 8) on Source tasks. ContentSource can usually go higher (16 to 32) if reading from a snapshot. Halve it if you are hitting prod. |
+| **Batch / page size** | Records fetched per API round-trip | Match to source page-size sweet spot. P8 likes 100 to 500; CMIS likes 50 to 200. Bigger pages reduce round-trip overhead but increase per-call memory. |
 | **Queue routing across workers** | Horizontal scale-out to extra machines | The broker (port 1789) dispatches punnets to whichever worker picks them up. Add machines and you don't reconfigure the campaign. |
 | **Time-window campaigns** | When extraction is allowed to run | Schedule scan-heavy work outside business hours. Fast2 campaigns are restartable, so you don't lose progress when you pause. |
 | **Two-stage split: Source vs ContentSource** | Decouples cheap metadata pass from heavy bytes pass | The single biggest knob. Do all your scans first, queue everything, then turn on ContentSource workers under controlled throttling. |
@@ -111,29 +111,29 @@ Whichever methodology you pick, the same set of Fast2 levers determines whether 
 
 Two layers around Fast2 are non-negotiable on a live source.
 
-**Source-side resource governance.** Lean on what the database already gives you. Oracle Resource Manager can cap the migration user to a fixed share of CPU and parallel-query slots; SQL Server Resource Governor can do the same with a dedicated workload group. Think of it as defence in depth. Fast2's throttling is the primary control, but you want the DBA's hand on a second valve.
+**Source-side resource governance.** Lean on what the database already gives you. Oracle Resource Manager can cap the migration user to a fixed share of CPU and parallel-query slots; SQL Server Resource Governor does the same with a dedicated workload group. Defence in depth. Fast2's throttling is your primary control, but you still want the DBA's hand on a second valve.
 
-**Joint runbook and a kill switch the source team owns.** The migration team does not get to decide that extraction continues when the source team says stop. Write this into the runbook on day one. The source-side ops engineer has a one-command kill (a `docker stop` on the worker, drain the queue, or pause the campaign in the Fast2 UI), and they never have to ask permission.
+**Joint runbook and a kill switch the source team owns.** The migration team does not get to decide that extraction keeps running after the source team says stop. Write that into the runbook on day one. The source-side ops engineer gets a one-command kill (a `docker stop` on the worker, drain the queue, or pause the campaign in the Fast2 UI), and they never have to ask permission to use it.
 
-**Reconciliation as a deliverable.** Don't ship reconciliation as a side report. Ship it as a numbered artifact: manifest of every source ID, target ID, SHA-256 hash, byte count, extraction timestamp; counts reconciled per business domain; a sampled set of rehydrated documents opened end-to-end in the target. The MAN Energy Solutions Documentum-to-OpenText project on ~2M documents made audit-compliant traceability a deliverable rather than a by-product, and that is the bar to hold yourself to. Fast2's NoSQL backend (Elasticsearch + Kibana on port 1791) gives you the dashboarding for free. Use it.
+**Reconciliation as a deliverable.** Don't bury reconciliation in a side report. Ship it as a numbered artifact: a manifest of every source ID, target ID, SHA-256 hash, byte count, and extraction timestamp; counts reconciled per business domain; a sampled set of rehydrated documents opened end-to-end in the target. The MAN Energy Solutions Documentum-to-OpenText project on ~2M documents treated audit-compliant traceability as a deliverable instead of a by-product. That's the bar. Fast2's NoSQL backend (Elasticsearch + Kibana on port 1791) hands you the dashboarding for free, so use it.
 
-One pattern worth naming briefly here, because it belongs in Part 2: you will sometimes want to mark documents in the source as migrated, so subsequent delta runs and eventual decommissioning can tell what has been processed. Fast2 supports this as a pattern, not as a one-click feature. Implementation, rollback, and DBA sign-off are covered in the delta-migration article.
+One more pattern, named only briefly because it really belongs in Part 2: you'll sometimes want to mark documents in the source as migrated, so later delta runs and the eventual decommissioning can tell what's already been processed. Fast2 supports this as a pattern, not a one-click feature. Implementation, rollback, and DBA sign-off are covered in the delta-migration article.
 
 ---
 
 ## A planning baseline you can defend
 
-Sizing conversations always come back to the same question: how fast does Fast2 actually go?
+Sizing conversations always circle back to one question: how fast does Fast2 actually go?
 
-For API-bound extraction (Clone & Sweep against a cloned app server, or Live Trickle against prod) plan around 50 to 100 documents per second per extraction thread. That anchor is a field-measured benchmark from our own engagements across FileNet, Documentum, and CMIS sources; TSG's publicly published multi-billion-document FileNet case study confirms migrations at this order of magnitude are real. With a dedup shortcut on already-known content, the heavier path can climb toward the top of that band.
+For API-bound extraction (Clone & Sweep against a cloned app server, or Live Trickle against prod) plan around 50 to 100 documents per second per extraction thread. That anchor is a field-measured benchmark from our own engagements across FileNet, Documentum, and CMIS sources, and TSG's publicly published multi-billion-document FileNet case study confirms migrations at this order of magnitude are real. Add a dedup shortcut on already-known content and the heavier path can climb toward the top of that band.
 
-For dump-bound extraction (Snapshot & Drip against a staging zone) throughput is governed by the staging zone's read bandwidth and the target's ingest capacity, not the source. This is where 120M docs/day numbers (Maretha) become reachable, because the source is out of the loop.
+For dump-bound extraction (Snapshot & Drip against a staging zone) the source isn't the bottleneck anymore. Throughput is governed by the staging zone's read bandwidth and the target's ingest capacity. That's how 120M docs/day numbers (Maretha) become reachable, because the source is out of the loop.
 
-A defensible back-of-envelope: 100M documents at 50 docs/sec/thread is about 23 days on a single thread, about 6 days on a 4-thread campaign, or roughly 2 days on 16 threads. Multiply by your own caution factor, typically 1.5x to 2x, for retries, business-day-only windows, and reconciliation overhead. Equisoft's published insurance-migration baseline of 1 to 3 years end-to-end covers the whole programme. Most of that range is design, validation, dual-run, and cutover. Extraction is one workstream.
+A defensible back-of-envelope: 100M documents at 50 docs/sec/thread is about 23 days on a single thread, about 6 days on a 4-thread campaign, roughly 2 days on 16 threads. Then multiply by your own caution factor, usually 1.5x to 2x, to cover retries, business-day-only windows, and reconciliation overhead. Equisoft's published insurance-migration baseline of 1 to 3 years end-to-end covers the whole programme, and most of that range is design, validation, dual-run, and cutover. Extraction is one workstream inside it.
 
 ### From the field: what these rates look like in practice
 
-The per-thread anchor above is for sizing arithmetic. What sponsors actually want is the shape of real campaigns, measured as **aggregate end-to-end throughput**: the whole pipeline, across however many threads and workers it was running, not per thread.
+The per-thread anchor above is for sizing arithmetic. What sponsors actually want is the shape of real campaigns, measured as **aggregate end-to-end throughput**: the whole pipeline, across however many threads and workers it was running. Not per thread.
 
 :::warning Before you quote any of these numbers
 **Read them as ceilings under specific conditions, not promises.** Every figure below is hostage to the environment around Fast2: the Fast2 server's own sizing (cores, RAM, worker count), how aggressively the flow was tuned, the source system's availability and DB optimisation (indexes on the scan predicate, resource-governor caps), the destination's resistance to sustained write load, and the network linking them. The same map can run at 8 or 150 docs/sec depending on what it does and what it runs against. Profile your own source before you commit to a date.
@@ -153,6 +153,6 @@ The per-thread anchor above is for sizing arithmetic. What sponsors actually wan
 
 ## Hand-off to Part 2
 
-Bulk extraction is half the job, and on a calendar it is usually the shorter half. While Fast2 sweeps through the snapshot, the source ECM keeps producing new documents. Claims filed Monday morning, charts updated Tuesday, contracts uploaded Wednesday. Your target has to catch up to now before anyone can cut over. That is the delta migration phase: change-data-capture vs watermark/timestamp vs source-side flagging, dual-run validation, reconciliation under load, and the cutover patterns (big-bang, phased, blue-green) that decide whether a project ends like TSB or like the 1.3B-document IBM-to-Alfresco-on-AWS insurer migration that Fast2 delivered in 22 months.
+Bulk extraction is half the job, and on a calendar it's usually the shorter half. While Fast2 sweeps through the snapshot, the source ECM keeps producing new documents. Claims filed Monday morning, charts updated Tuesday, contracts uploaded Wednesday. Your target has to catch up to *now* before anyone can cut over. That's the delta migration phase: change-data-capture vs watermark/timestamp vs source-side flagging, dual-run validation, reconciliation under load, and the cutover patterns (big-bang, phased, blue-green) that decide whether a project ends like TSB or like the 1.3B-document IBM-to-Alfresco-on-AWS insurer migration that Fast2 delivered in 22 months.
 
 **[Read Part 2: Delta Migration Methodology →](./delta-migration.md)**

--- a/docs/fast2/playbook/index.md
+++ b/docs/fast2/playbook/index.md
@@ -12,7 +12,7 @@ content_hash: 74879b07826c2f0ee5d4eab59c87b9a074164c9da98e524a96e83ae675beec5c
 
 The Playbook is the **strategy** layer of the Fast2 documentation. It is about the decisions you make *before* you configure a single task: which extraction strategy fits a live source, how you catch the target up to a moving source, and where you deploy Fast2 relative to the systems it connects. These are architecture and methodology choices, anchored in real field experience and real migration failures.
 
-:::tip Playbook vs. Cookbooks — which one do I need?
+:::tip Playbook vs. Cookbooks: which one do I need?
 Fast2 has two hands-on sections, and they answer two different questions.
 
 | | **Playbook** (this section) | **[Cookbooks](../cookbooks/)** |
@@ -20,7 +20,7 @@ Fast2 has two hands-on sections, and they answer two different questions.
 | **Question it answers** | *Which approach should I choose?* | *How do I implement this?* |
 | **Altitude** | Strategy & architecture | Tactics & recipes |
 | **Unit** | A methodology, a decision matrix, a trade-off | A task config, a code snippet, an API call |
-| **When you read it** | Before the project — during design and scoping | During the project — at the keyboard |
+| **When you read it** | Before the project, during design and scoping | During the project, at the keyboard |
 | **Example** | "Clone & Sweep vs. Snapshot & Drip for a live 800M-document FileNet source" | "Read content and metadata from S3 into a punnet" |
 
 A cookbook tells you how to cook one dish. The playbook tells you how to plan the menu for 500 guests, with dietary constraints and a two-hour service window. You will usually start in the Playbook to choose your approach, then drop into the Cookbooks to build it.
@@ -28,10 +28,10 @@ A cookbook tells you how to cook one dish. The playbook tells you how to plan th
 
 ## What's in here
 
-- **[Extracting From a Live ECM](./extracting-from-live-ecm.md)** — the three bulk-extraction methodologies (Clone & Sweep, Snapshot & Drip, Live Trickle), with a decision matrix, throttling controls, and a defensible sizing baseline. Part 1 of the migration series.
-- **[Delta Migration](./delta-migration.md)** — how the target catches up to a source that never stops: the four delta-capture mechanisms, layered reconciliation, cutover patterns, and the sign-off ritual. Part 2 of the migration series.
-- **[Deployment Variants](./deployment-variants.md)** — where to run Fast2 relative to the source and target: on-premise, cloud, hybrid, and AWS Snowball, with the access-control / performance / debugging trade-offs of each.
-- **[Content Integrity](./content-integrity.md)** — proving no content was corrupted or lost in transit: the three content-validation strategies (size, retrieved hash, computed hash), their trade-offs, and how Fast2 isolates, logs and retries mismatching assets.
-- **[Metadata Integrity](./metadata-integrity.md)** — preserving original creation/modification/retention dates and creator/owner identity in the destination, instead of having them overwritten by the migration run.
+- **[Extracting From a Live ECM](./extracting-from-live-ecm.md)**: the three bulk-extraction methodologies (Clone & Sweep, Snapshot & Drip, Live Trickle), with a decision matrix, throttling controls, and a defensible sizing baseline. Part 1 of the migration series.
+- **[Delta Migration](./delta-migration.md)**: how the target catches up to a source that never stops. The four delta-capture mechanisms, layered reconciliation, cutover patterns, and the sign-off ritual. Part 2 of the migration series.
+- **[Deployment Variants](./deployment-variants.md)**: where to run Fast2 relative to the source and target, from on-premise to cloud, hybrid, and AWS Snowball, with the access-control, performance, and debugging trade-offs of each.
+- **[Content Integrity](./content-integrity.md)**: proving no content was corrupted or lost in transit. The three content-validation strategies (size, retrieved hash, computed hash), their trade-offs, and how Fast2 isolates, logs and retries mismatching assets.
+- **[Metadata Integrity](./metadata-integrity.md)**: preserving original creation, modification, and retention dates plus creator/owner identity in the destination, instead of letting the migration run overwrite them.
 
 These articles are written from the field. They name real projects and real failures, because the point of a playbook is to help you avoid repeating them.

--- a/docs/fast2/playbook/metadata-integrity.md
+++ b/docs/fast2/playbook/metadata-integrity.md
@@ -6,13 +6,13 @@ sidebar_position: 5
 
 # Preserving Metadata & System Fields
 
-In many migrations — especially those driven by legal or audit requirements — the **original metadata must be preserved** in the destination: creation dates, retention dates, modification dates, and the identity of the original creator/owner. The risk is that a naive migration overwrites these with the migration date and the migration service account.
+In a lot of migrations, and especially the ones driven by legal or audit requirements, the **original metadata has to survive the move**: creation dates, retention dates, modification dates, and who originally created or owned the document. Get it wrong and a naive migration stamps everything with today's date and whatever service account ran the job. That's exactly what an auditor doesn't want to find.
 
 This playbook explains how Fast2 keeps original values intact, and what the destination system and the project team must provide for it to work. It is written to be **system-agnostic**: "source system" and "destination system" stand for whatever you migrate from and to.
 
 :::tip TL;DR
 - Fast2 **passes source values through unchanged** unless a mapping step is intentionally configured to transform them.
-- **Dates** are preserved as-is when both systems share the same format and timezone — no conversion needed.
+- **Dates** carry over untouched when both systems share the same format and timezone. No conversion needed.
 - **Creator / owner / modifier** are set by *referencing* identities (“profiles”) that must already exist in the destination.
 - **Read-only / system fields** are typically *settable-once-at-creation*: Fast2 sets them at document creation through the destination's official API, using credentials with sufficient permissions.
 - A built-in **migration-asset tracking system** lets you verify the state of any asset at any step; UAT and business validation remain essential.
@@ -20,7 +20,7 @@ This playbook explains how Fast2 keeps original values intact, and what the dest
 
 ## Keeping source values unchanged
 
-If the format of the expected value in the destination is the same as the source (ex/ same date format, numbers stored under *integer* or *String* or *Decimal* data) Fast2 can keep these values and will not update those unless stated otherwise (like, adding a property mapping step updating not only the name — so it fits the expected nomenclature of the destination — but also the value). This would be an “intentional” migration step added during the workflow design phase.
+If the format of the expected value in the destination is the same as the source (ex/ same date format, numbers stored under *integer* or *String* or *Decimal* data) Fast2 can keep these values and will not update those unless stated otherwise (like, adding a property mapping step updating not only the name, so it fits the expected nomenclature of the destination, but also the value). This would be an “intentional” migration step added during the workflow design phase.
 
 ## Tracking and validation
 
@@ -40,10 +40,10 @@ As for the *read-only* values, usually they are just settable-only-once-at-creat
 
 ## In practice
 
-Three conditions make read-only field preservation succeed: the **destination must expose** the field at creation time through its API, the migration account must hold **sufficient permissions** to set it, and any referenced identities (creators, owners) must **already exist** in the destination. Confirm these three points early — ideally during the discovery / PoC phase — because they are properties of the destination system, not of Fast2 itself.
+Read-only field preservation works when three things line up: the **destination exposes** the field at creation time through its API, the migration account has **enough permission** to set it, and any creators or owners you reference **already exist** on the destination side. Pin these down early, during discovery or the PoC. They're properties of the destination system, not of Fast2, so finding out late tends to be expensive.
 
 :::info Related
 - [Transformation tasks](../catalog/transformer.md) for property mapping
 - [Credentials](../catalog/credentials.md) for configuring the migration account
-- [Content Integrity](./content-integrity.md) — the companion content-validation playbook
+- [Content Integrity](./content-integrity.md): the companion content-validation playbook
 :::


### PR DESCRIPTION
Strip every long dash (em/en/horizontal/minus) used as punctuation across the five playbook articles + the section index, and rewrite the prose in a natural, human voice (varied cadence, contractions, fewer AI tells). All technical facts, tables, links, code, admonitions, mermaid, and frontmatter preserved; meaning unchanged.


Claude-Session: https://claude.ai/code/session_01PcwPw4RfxftL4iM4PWTJq8