### PR TITLE
FD-18516 Add MCP Server documentation

### DIFF
--- a/docs/flowerdocs/connecteurs/mcp/_category_.json
+++ b/docs/flowerdocs/connecteurs/mcp/_category_.json
@@ -1,0 +1,5 @@
+{
+    "label": "MCP Server",
+    "link": null,
+    "position": 4
+}

--- a/docs/flowerdocs/connecteurs/mcp/getting-started.md
+++ b/docs/flowerdocs/connecteurs/mcp/getting-started.md
@@ -1,0 +1,127 @@
+---
+title: Getting Started
+sidebar_position: 1
+date: "2026-07-21T09:00:00+02:00"
+---
+
+# FlowerDocs MCP Server
+
+The FlowerDocs MCP server exposes FlowerDocs **administration and configuration management** as tools that an AI assistant can call, using the [Model Context Protocol](https://modelcontextprotocol.io). Connect it to Claude Desktop or Claude Code and drive FlowerDocs in natural language: create tag classes, edit GUI configurations, manage scripts and operation handlers, purge caches, and more.
+
+It runs as a standalone service alongside your FlowerDocs Core and GUI, and speaks the Model Context Protocol over the Streamable HTTP transport.
+
+:::info It is an administration tool
+Every tool runs under real FlowerDocs user credentials, and the whole server is gated by a shared access key. It is meant for administrators and integrators. See [Authentication](../install#authentication). Do not expose it openly on the internet.
+:::
+
+## Prerequisites
+
+- **Java 25**
+- Running **FlowerDocs Core** and **FlowerDocs GUI** instances.
+- **FlowerDocs user credentials**: the MCP always authenticates; there is no anonymous access.
+- The **MCP access key** for your deployment (ask your administrator).
+
+## Connect your AI client
+
+Once the server is running (see [Installation](../install)), the MCP endpoint is available at `http://localhost:8086/flowerdocs-mcp/mcp`. Point your client at it and add the required headers.
+
+### Claude Desktop
+
+Edit `claude_desktop_config.json` (**Windows**: `%APPDATA%\Claude\`, **Mac**: `~/Library/Application Support/Claude/`):
+
+```json
+{
+  "mcpServers": {
+    "flowerdocs": {
+      "command": "mcp-remote",
+      "args": [
+        "http://localhost:8086/flowerdocs-mcp/mcp",
+        "--header", "X-FlowerDocs-Access-Key: ENC(yourEncryptedAccessKey)",
+        "--header", "X-FlowerDocs-User: yourUsername",
+        "--header", "X-FlowerDocs-Password: ENC(yourEncryptedPassword)",
+        "--header", "X-FlowerDocs-Scope: FD"
+      ]
+    }
+  }
+}
+```
+
+`mcp-remote` bridges URL-based MCP servers for Claude Desktop; install it with `npm install -g mcp-remote`. Restart Claude Desktop; **flowerdocs** appears as a connected server.
+
+### Claude Code
+
+Add to `.mcp.json` in your project (or `~/.claude/.mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "flowerdocs": {
+      "type": "url",
+      "url": "http://localhost:8086/flowerdocs-mcp/mcp",
+      "headers": {
+        "X-FlowerDocs-Access-Key": "ENC(yourEncryptedAccessKey)",
+        "X-FlowerDocs-User": "yourUsername",
+        "X-FlowerDocs-Password": "ENC(yourEncryptedPassword)",
+        "X-FlowerDocs-Scope": "FD"
+      }
+    }
+  }
+}
+```
+
+Launch Claude Code; the server connects automatically.
+
+### Other MCP clients
+
+Any MCP-compatible client works, since the server speaks the standard Streamable HTTP transport. Point the client at the same URL and pass the same four headers. For example, in Cursor (`.cursor/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "flowerdocs": {
+      "url": "http://localhost:8086/flowerdocs-mcp/mcp",
+      "headers": {
+        "X-FlowerDocs-Access-Key": "ENC(yourEncryptedAccessKey)",
+        "X-FlowerDocs-User": "yourUsername",
+        "X-FlowerDocs-Password": "ENC(yourEncryptedPassword)",
+        "X-FlowerDocs-Scope": "FD"
+      }
+    }
+  }
+}
+```
+
+The same applies to other MCP-capable assistants (VS Code, Cline, and similar). To browse and call the tools interactively without an assistant, use the [MCP Inspector](https://github.com/modelcontextprotocol/inspector), selecting the **Streamable HTTP** transport and the URL above.
+
+## Try it out
+
+Once connected, ask your assistant:
+
+> List all the admin entity types available.
+
+> Show me all tag classes defined in the FD scope.
+
+> Create a tag class called "InvoiceAmount" of type INT, make it searchable.
+
+> Show me the XML content of the GUI configuration "search-form-invoice".
+
+> Update the script "validate-invoice" to add a check on the InvoiceAmount tag.
+
+## What the assistant can do
+
+The tools are grouped into families:
+
+| Family | Purpose |
+|--------|---------|
+| **Admin entities** | Generic CRUD over tag classes, component classes, ACLs, tag categories, workflows |
+| **Team configuration** | Update a scope's team settings, such as profile tabs |
+| **Class helpers** | Field-type discovery, appending allowed values / tag references |
+| **Technical documents** | GUI configurations, scripts, operation handlers, CSS, routes, templates, pages |
+| **Cache** | List and purge Core caches after bulk configuration changes |
+| **Config components** | Instances of technical virtual-folder / folder classes (e.g. profile tabs) |
+
+Each tool is advertised with `readOnly` / `destructive` hints, so a client such as Claude Desktop groups read-only tools apart from a **Write / delete tools** group and can ask for confirmation before running the destructive ones.
+
+## Pair it with the documentation
+
+Tool descriptions are intentionally minimal to keep the token budget small. For the assistant to produce correct XML, script APIs or operation-handler configurations, give it access to this FlowerDocs documentation through a companion MCP server (a filesystem or GitHub MCP pointed at the docs). The assistant then combines both: it discovers a field schema with `technicaldoc_describe`, reads the matching documentation page, and writes the document with `technicaldoc_create`.

--- a/docs/flowerdocs/connecteurs/mcp/getting-started.md
+++ b/docs/flowerdocs/connecteurs/mcp/getting-started.md
@@ -6,7 +6,7 @@ date: "2026-07-21T09:00:00+02:00"
 
 # FlowerDocs MCP Server
 
-The FlowerDocs MCP server exposes FlowerDocs **administration and configuration management** as tools that an AI assistant can call, using the [Model Context Protocol](https://modelcontextprotocol.io). Connect it to Claude Desktop or Claude Code and drive FlowerDocs in natural language: create tag classes, edit GUI configurations, manage scripts and operation handlers, purge caches, and more.
+The FlowerDocs MCP server exposes FlowerDocs **administration and configuration management** as tools that an AI assistant can call, using the [Model Context Protocol](https://modelcontextprotocol.io). Connect any MCP-compatible assistant (Claude Desktop, Claude Code, Cursor, VS Code, and others) and drive FlowerDocs in natural language: create tag classes, edit GUI configurations, manage scripts and operation handlers, purge caches, and more.
 
 It runs as a standalone service alongside your FlowerDocs Core and GUI, and speaks the Model Context Protocol over the Streamable HTTP transport.
 

--- a/docs/flowerdocs/connecteurs/mcp/install.md
+++ b/docs/flowerdocs/connecteurs/mcp/install.md
@@ -1,0 +1,93 @@
+---
+title: Installation
+sidebar_position: 2
+date: "2026-07-21T09:00:00+02:00"
+---
+
+# Installation
+
+The MCP server is a standalone Spring Boot service. It ships as a JAR and a Docker image. Whichever you use, the configuration keys are the same.
+
+## Get the server
+
+- **JAR**: the latest `flower-docs-mcp-server.jar`, available from the [release notes](../release-notes).
+- **Docker**: the delivered `flower-docs-mcp-server` image (exposes port `8086`, with a built-in `HEALTHCHECK`).
+
+## Configure it
+
+Drop an `application.properties` **next to the JAR**.
+
+```properties
+ws.url=http://localhost:8081/core/rest
+gui.url=http://localhost:8080/gui/rest
+secret=<your-secret-key>
+mcp.access.key=<your-mcp-access-key>
+```
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `ws.url` | `http://localhost:8081/core/rest` | FlowerDocs Core REST endpoint |
+| `gui.url` | `http://localhost:8080/gui/rest` | FlowerDocs GUI REST base. The MCP purges GUI-side caches after a configuration/script/CSS update so the change appears without a manual admin purge. Set empty to disable |
+| `secret` | *(required)* | Key that decrypts the `ENC(...)` values (the access key and passwords) |
+| `mcp.access.key` | *(required)* | Shared access key that gates every request (see [Authentication](#authentication)) |
+
+Any property can also be set via an environment variable (`WS_URL=...`, `MCP_ACCESS_KEY=...`) or a command-line argument (`--ws.url=...`).
+
+## Start it
+
+```bash
+java -jar flower-docs-mcp-server.jar
+```
+
+The MCP endpoint is then available at `http://localhost:8086/flowerdocs-mcp/mcp`.
+
+## Health check
+
+`GET /flowerdocs-mcp/actuator/status` returns a bare `UP` / `DOWN` (no health details). It reports **DOWN** when FlowerDocs Core or GUI is unreachable, by probing their own `/actuator/status`. Use it for the container healthcheck and load-balancer / monitoring probes:
+
+```bash
+curl http://localhost:8086/flowerdocs-mcp/actuator/status   # UP when core and gui are reachable
+```
+
+## Authentication
+
+Each client authenticates via HTTP headers. There is no shared service account; every user provides their own credentials.
+
+### Required headers
+
+| Header | Description |
+|--------|-------------|
+| `X-FlowerDocs-Access-Key` | Shared MCP access key, required on **every** request; **must** be `ENC(...)` |
+| `X-FlowerDocs-User` | FlowerDocs username |
+| `X-FlowerDocs-Password` | FlowerDocs password, which **must** be `ENC(...)` (plaintext is rejected) |
+| `X-FlowerDocs-Scope` | FlowerDocs scope / tenant ID (e.g. `FD`) |
+
+### Shared access key
+
+The access key is a **second factor that gates the whole server**, independent of who the user is. Even a valid FlowerDocs user cannot reach the MCP without it. Exposing the endpoint does not, on its own, grant access to your FlowerDocs data.
+
+It is a single shared value. You configure it server-side as `mcp.access.key` and give it to the clients you trust. To rotate it, change the property and update those clients.
+
+Every request to the MCP endpoint and to `/encrypt` must carry the `X-FlowerDocs-Access-Key` header. It **must** be `ENC(...)`; plaintext is rejected, the same policy as passwords. So the key is never stored in clear in a client's configuration. The server decrypts the header and compares it to its configured key in constant time. A mismatch returns `403`. The server also refuses to start unless both `secret` and `mcp.access.key` are set, so a deployment can never come up unprotected.
+
+### Encrypted passwords
+
+Passwords must be sent as `ENC(...)`. An `ENC(...)` value can only be decrypted by the key that produced it, so the MCP's `secret` must match whatever encrypted the value.
+
+### Producing `ENC(...)` values
+
+Once the server is up, use its own `/encrypt` endpoint. It holds the same `secret` and returns a value already wrapped as `ENC(...)`:
+
+```bash
+curl -X POST http://localhost:8086/flowerdocs-mcp/encrypt \
+  -H "X-FlowerDocs-Access-Key: ENC(yourEncryptedAccessKey)" \
+  -H "Content-Type: text/plain" \
+  -d "yourPassword"
+# -> ENC(Nhbs45YyYLhmY44udE2fAitLoJywdoSm)
+```
+
+A Swagger UI is served at `/flowerdocs-mcp/swagger-ui/index.html`: enter the access key and the value to encrypt, and copy the `ENC(...)` result.
+
+:::warning Bootstrapping the access key
+`/encrypt` is itself gated by the access key, so you cannot use it to encrypt the access key the first time. Produce that first `ENC(...)` value out-of-band. See [Encrypting a character string](../../../apis/core/examples/stringEncryptor) or the [CLM documentation](../../../install/clm/clm).
+:::

--- a/docs/flowerdocs/connecteurs/mcp/release-notes.md
+++ b/docs/flowerdocs/connecteurs/mcp/release-notes.md
@@ -1,0 +1,76 @@
+---
+title: Release Notes
+sidebar_position: 3
+description: "First release of the FlowerDocs MCP Server: 26 tools for administration, configuration components and technical documents, per-user authentication, and an independent release train."
+date: "2026-07-21T09:00:00+02:00"
+---
+
+import FlowerDocsMcpDownload from '@site/src/components/FlowerDocsMcpDownload';
+
+# FlowerDocs MCP Server Release Notes
+
+## 2026.1.0-ft0
+
+### 💡 Overview
+
+The FlowerDocs MCP Server gives access to FlowerDocs configuration, creating tag, document, folder or task classes, adjusting a workflow, updating a GUI configuration directly through XML files, without going through the admin GUI or requiring custom development. An MCP-compatible AI assistant (Claude Desktop, Claude Code, or any other compatible client) acts as the interface for driving this configuration in natural language. This first version covers full administration (tag/document/folder/task classes, virtual folder classes, ACLs, scopes, workflows), technical documents (scripts, GUI configurations, operation handlers, CSS, routes), configuration components (profile tabs and other technical virtual folder / folder instances), and cache visibility.
+
+This is its first release note. The server has its own release train, independent from FlowerDocs. It will move at its own pace, including between two FlowerDocs releases, so you can expect update notes here more frequently than for FlowerDocs itself.
+
+For installation and configuration, see the [MCP Server documentation](../getting-started).
+
+### 🔌 Compatibility
+
+| | |
+|---|---|
+| Server version | 2026.1.0-ft0 |
+| Compatible FlowerDocs versions | 2026.0.0 and later versions of the 2026 line |
+| MCP protocol revision | 2025-11-25 (latest; earlier revisions down to 2024-11-05 negotiated for compatibility) |
+| Transport | Streamable HTTP (`/mcp`) |
+| Authentication | Per-user HTTP headers (encrypted passwords supported) |
+
+### 🔒 Security
+
+Every action runs under the permissions of the FlowerDocs user connected to the assistant. There is no shared service account. An assistant can therefore never do more than that user is already allowed to do in FlowerDocs.
+
+### ✨ Features
+
+#### ⚙️ Administration & configuration
+
+An assistant can create and update tag classes, document classes, folder classes, task classes, virtual folder classes, ACLs, scopes and tag categories, following a discover-then-act pattern: it checks what a given entity type expects (`admin_describe`) before creating or modifying one, rather than guessing the structure. Task classes can also be chained into a real sequential process through a dedicated workflow entity type.
+
+To avoid unpleasant surprises, the server guides the assistant to ask the right questions at creation time: description in French and English, versioning mode, tag categories and tag references to associate, rather than silently applying default values.
+
+All tag types are supported, including CONDITIONAL types, whose proposed values adapt dynamically based on a parent tag.
+
+Tools: `admin_list_types`, `admin_describe`, `admin_create`, `admin_get`, `admin_list`, `admin_update`, `admin_delete`, `list_field_types`, `add_allowed_values`, `add_tag_reference`
+
+#### 📄 Technical documents
+
+The server also manages the technical documents that shape how FlowerDocs looks and behaves: GUI configurations, scripts, operation handlers, CSS and routes, including reading and writing their full file content. This lets an assistant help author or adjust these building blocks directly, rather than editing them by hand.
+
+Tool descriptions are deliberately minimal. To take configuration further we recommend pairing this server with the MCP Server documentation, which describes the expected structure for each type of technical document.
+
+Tools: `technicaldoc_list_types`, `technicaldoc_describe`, `technicaldoc_search`, `technicaldoc_get`, `technicaldoc_get_content`, `technicaldoc_create`, `technicaldoc_update`, `technicaldoc_delete`
+
+#### 🧩 Configuration components
+
+Beyond the classes themselves, the server creates and manages instances of technical virtual folder and folder classes, for example the virtual folder that becomes a profile tab. It can create, read, search, update and delete these instances.
+
+Tools: `configcomponent_create`, `configcomponent_get`, `configcomponent_search`, `configcomponent_update`, `configcomponent_delete`
+
+#### 🗃️ Caches
+
+Cache contents can be listed and purged directly, either for a specific target or entirely. Updating a GUI configuration, script or CSS file automatically purges the corresponding GUI-side caches, so the change appears in the interface without a manual admin purge.
+
+Tools: `cache_list`, `cache_purge_for`, `cache_purge_all`
+
+#### 🏗️ Infrastructure
+
+At startup, the server checks that FlowerDocs Core is reachable and keeps retrying for a configurable window before giving up, so a slow Core start during a coordinated restart won't fail the MCP server outright. Its health endpoint reflects that connectivity, which makes it straightforward to plug into a monitoring or load-balancer check. Requests are validated against the documented schema, and unsupported fields are rejected with a clear error rather than being silently ignored.
+
+### 🐛 Known issues
+
+None known at this release.
+
+<FlowerDocsMcpDownload version="2026.1.0-ft0" />

--- a/docs/flowerdocs/connecteurs/mcp/release-notes.md
+++ b/docs/flowerdocs/connecteurs/mcp/release-notes.md
@@ -15,7 +15,7 @@ import FlowerDocsMcpDownload from '@site/src/components/FlowerDocsMcpDownload';
 
 The FlowerDocs MCP Server gives access to FlowerDocs configuration, creating tag, document, folder or task classes, adjusting a workflow, updating a GUI configuration directly through XML files, without going through the admin GUI or requiring custom development. An MCP-compatible AI assistant (Claude Desktop, Claude Code, or any other compatible client) acts as the interface for driving this configuration in natural language. This first version covers full administration (tag/document/folder/task classes, virtual folder classes, ACLs, scopes, workflows), technical documents (scripts, GUI configurations, operation handlers, CSS, routes), configuration components (profile tabs and other technical virtual folder / folder instances), and cache visibility.
 
-This is its first release note. The server has its own release train, independent from FlowerDocs. It will move at its own pace, including between two FlowerDocs releases, so you can expect update notes here more frequently than for FlowerDocs itself.
+This is its first release note. The server has its own fast-track release train, independent from FlowerDocs, and may be updated between FlowerDocs releases.
 
 For installation and configuration, see the [MCP Server documentation](../getting-started).
 

--- a/src/components/FlowerDocsCards/index.tsx
+++ b/src/components/FlowerDocsCards/index.tsx
@@ -140,6 +140,12 @@ function GuidesCard({ title, description, items, color }) {
 
 const ConnectorsList = [
     {
+        title: "MCP Server",
+        icon: "🤖",
+        description: "Drive FlowerDocs administration from an AI assistant",
+        link: "/docs/flowerdocs/connecteurs/mcp/getting-started",
+    },
+    {
         title: "FlowerDocs Companion",
         logo: "/img/flowerdocs/documentation/microsoft.png",
         description:
@@ -154,13 +160,17 @@ const ConnectorsList = [
     },
 ];
 
-function ConnectorCard({ title, logo, description, link }) {
-    const logoUrl = useBaseUrl(logo);
+function ConnectorCard({ title, logo, icon, description, link }) {
+    const logoUrl = useBaseUrl(logo || "");
 
     return (
         <Link to={link} className={styles.connectorCard}>
             <div className={styles.connectorIcon}>
-                <img src={logoUrl} alt={`${title} logo`} />
+                {logo ? (
+                    <img src={logoUrl} alt={`${title} logo`} />
+                ) : (
+                    <span style={{ fontSize: "2.5rem", lineHeight: 1 }}>{icon}</span>
+                )}
             </div>
             <h4 className={styles.connectorTitle}>{title}</h4>
             <p className={styles.connectorDescription}>{description}</p>

--- a/src/components/FlowerDocsCards/styles.module.css
+++ b/src/components/FlowerDocsCards/styles.module.css
@@ -550,7 +550,7 @@
 
 .connectorsGrid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
     gap: 1.25rem;
     max-width: 1200px;
 }

--- a/src/components/FlowerDocsMcpDownload/index.tsx
+++ b/src/components/FlowerDocsMcpDownload/index.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import styles from '../FlowerDocsDownloads/styles.module.css';
+
+interface FlowerDocsMcpDownloadProps {
+    version: string;
+}
+
+const FlowerDocsMcpDownload: React.FC<FlowerDocsMcpDownloadProps> = ({ version }) => {
+    const baseUrl = "https://artifactory.arondor.cloud/artifactory/arondor-release";
+    const artifactPath = "com/flower/docs/flower-docs-mcp-server";
+    const fileName = `flower-docs-mcp-server-${version}.jar`;
+    const downloadUrl = `${baseUrl}/${artifactPath}/${version}/${fileName}`;
+    const sha256Url = `${downloadUrl}.sha256`;
+
+    return (
+        <div className={styles.downloadsSection}>
+            <h2 className={styles.downloadsTitle}>Downloads</h2>
+
+            <div className={styles.downloadItem}>
+                <div className={styles.downloadInfo}>
+                    <h6 className={styles.downloadTitle}>FlowerDocs MCP Server</h6>
+                    <p className={styles.downloadDescription}>
+                        MCP server exposing FlowerDocs administration and configuration as tools
+                    </p>
+                </div>
+                <div className={styles.downloadButtons}>
+                    <a
+                        href={sha256Url}
+                        className={styles.downloadButton}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        Sha256
+                    </a>
+                    <a
+                        href={downloadUrl}
+                        className={`${styles.downloadButton} ${styles.downloadButtonPrimary}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        JAR
+                    </a>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default FlowerDocsMcpDownload;


### PR DESCRIPTION
Adds the **FlowerDocs MCP Server** documentation under `docs/flowerdocs/connecteurs/mcp` (FD-18516), matching the ticket: Getting started, Installation, Release notes.

**Pages**
- `getting-started` — overview, prerequisites (Java 25, Core + GUI), client setup (Claude Desktop, Claude Code, other MCP clients / Cursor / MCP Inspector), sample prompts, tool families.
- `install` — get the JAR (linked to the release notes), configuration, health check, authentication (shared access key + encrypted passwords), producing `ENC(...)` values, bootstrapping.
- `release-notes` — `2026.1.0-ft0`, verified against the MCP code: 26 tools (incl. `add_tag_reference` and the config-component tools), compatibility (MCP protocol revision **2025-11-25**, negotiated, confirmed from `io.modelcontextprotocol:mcp-core:2.0.0`), no known issues.

**Components**
- New `FlowerDocsMcpDownload` (same card + Artifactory link scheme as `FlowerDocsDownloads`).
- MCP Server card added first on the FlowerDocs connectors landing; connectors grid fits on one line.

**Test:** rendered locally with `docusaurus start`; internal links use the repo's extension-less, `trailingSlash`-aware convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
