### PR TITLE
FD-18574 add 2026.1.0 upgrade notes, restructure heading levels

### DIFF
--- a/docs/flowerdocs/install/config/core-config.md
+++ b/docs/flowerdocs/install/config/core-config.md
@@ -10,7 +10,7 @@ content_hash: f51d5da6b342612ec68b8cdf08c8101e1c27b67a7a38815b217b513e47c71796
 
 This section describes the various FlowerDocs Core configurations to be defined in the application's `core.properties` file.
 
-# General
+## General
 
 | Property              | Description                                                      |
 | --------------------- | ---------------------------------------------------------------- |
@@ -20,14 +20,14 @@ This section describes the various FlowerDocs Core configurations to be defined 
 | secret                | Secret used to encode password _(optional)_                      |
 | core.context          | Application context                                              |
 
-# Logging
+## Logging
 
 | Property           | Description                                 |
 | ------------------ | ------------------------------------------- |
 | logging.file.name  | Log file path and name                      |
 | logging.level.root | Log level: `WARN`, `ERROR`, `INFO`, `DEBUG` |
 
-# OpenSearch
+## OpenSearch
 
 | Property    | Description                                                  |
 | ----------- | ------------------------------------------------------------ |
@@ -35,7 +35,7 @@ This section describes the various FlowerDocs Core configurations to be defined 
 | opensearch.username | User name _(optional)_                                       |
 | opensearch.password | User password _(optional)_                                   |
 
-# Redis
+## Redis
 
 | Property          | Description                                         |
 | ----------------- | --------------------------------------------------- |
@@ -43,7 +43,7 @@ This section describes the various FlowerDocs Core configurations to be defined 
 | spring.data.redis.host | Host name Redis                                |
 | spring.data.redis.port | Redis listening port                           |
 
-# ARender
+## ARender
 
 | Property                | Description                                                  |
 | ----------------------- | ------------------------------------------------------------ |
@@ -51,25 +51,25 @@ This section describes the various FlowerDocs Core configurations to be defined 
 
 It is not recommended to modify ARender properties by setting parameters in the `core.properties` file. Properties that are not defined in the documentation are not qualified by FlowerDocs: the correct operation of the application is therefore not guaranteed with these modifications.
 
-# Connection pools and timeouts
+## Connection pools and timeouts
 
 The connection pools and timeouts of the main infrastructure components are configurable. Defaults are tuned for a typical load; adjust them per environment.
 
-## OpenSearch
+### OpenSearch client
 
 | Property | Description |
 | --- | --- |
 | `opensearch.pool.max.total` / `opensearch.pool.max.per.route` | HTTP connection pool size (default `200`) |
 | `opensearch.connect.timeout` / `opensearch.socket.timeout` | Connect and read timeouts (default `5000` / `60000` ms) |
 
-## REST OperationHandler
+### REST OperationHandler client
 
 | Property | Description |
 | --- | --- |
 | `rest.oh.pool.max.total` / `rest.oh.pool.max.per.route` | Client pool size (default `200` / `100`) |
 | `rest.oh.connect.timeout` / `rest.oh.read.timeout` | Callback connect and read timeouts (default `5000` / `30000` ms) |
 
-## ARender rendition
+### ARender rendition client
 
 The pool Core uses to reach the ARender rendition service.
 
@@ -92,6 +92,6 @@ Two points worth knowing:
 - The ARender HMI has its own pool with the same defaults, configured in ARender's own files. If the viewer and thumbnails traverse the same load balancer, set `arender.server.rendition.rest.max.idle.time` there too.
 - Do not confuse this namespace with `rest.client.*`, which configures the rendition broker's outgoing calls to its microservices and belongs on the broker, not on Core.
 
-# Security headers
+## Security headers
 
 The GUI sends a Content-Security-Policy and browser security headers. Override these only if you embed FlowerDocs, serve assets from a custom CDN, or run a companion application on a non-default port: `content.security.policy`, `content.security.policy.directives`, `hsts.max.age`, `referrer.policy`, `permissions.policy`, `cross.origin.opener.policy`, `cross.origin.resource.policy`.

--- a/docs/flowerdocs/install/config/core-config.md
+++ b/docs/flowerdocs/install/config/core-config.md
@@ -55,12 +55,42 @@ It is not recommended to modify ARender properties by setting parameters in the 
 
 The connection pools and timeouts of the main infrastructure components are configurable. Defaults are tuned for a typical load; adjust them per environment.
 
+## OpenSearch
+
 | Property | Description |
 | --- | --- |
-| `opensearch.pool.max.total` / `opensearch.pool.max.per.route` | OpenSearch HTTP connection pool size (default `200`) |
-| `opensearch.connect.timeout` / `opensearch.socket.timeout` | OpenSearch connect / read timeout (default `5000` / `60000` ms) |
-| `rest.oh.connect.timeout` / `rest.oh.read.timeout` | REST OperationHandler callback timeouts (default `5000` / `30000` ms) |
-| `rest.oh.pool.max.total` / `rest.oh.pool.max.per.route` | REST OperationHandler client pool (default `200` / `100`) |
+| `opensearch.pool.max.total` / `opensearch.pool.max.per.route` | HTTP connection pool size (default `200`) |
+| `opensearch.connect.timeout` / `opensearch.socket.timeout` | Connect and read timeouts (default `5000` / `60000` ms) |
+
+## REST OperationHandler
+
+| Property | Description |
+| --- | --- |
+| `rest.oh.pool.max.total` / `rest.oh.pool.max.per.route` | Client pool size (default `200` / `100`) |
+| `rest.oh.connect.timeout` / `rest.oh.read.timeout` | Callback connect and read timeouts (default `5000` / `30000` ms) |
+
+## ARender rendition
+
+The pool Core uses to reach the ARender rendition service.
+
+| Property | Description |
+| --- | --- |
+| `arender.server.rendition.rest.max.connections` | Pool size, beyond which requests wait for a free connection (default `200`) |
+| `arender.server.rendition.rest.pending.acquire.timeout` / `arender.server.rendition.rest.pending.acquire.max.count` | How long a request waits for a pooled connection, and how many may wait (default `120000` ms / `-1`, no limit) |
+| `arender.server.rendition.rest.max.idle.time` / `arender.server.rendition.rest.max.life.time` | Close a connection after it has been idle, or after it has existed, for this long (default `-1` for both, meaning never) |
+| `arender.server.rendition.rest.read.timeout` / `arender.server.rendition.rest.write.timeout` | Read and write timeouts (default `120000` ms) |
+| `arender.server.rendition.rest.max.in.memory.size` | Maximum number of bytes buffered in memory (default `8000000`) |
+
+:::warning Set `max.idle.time` below any idle timeout on the network path
+If Core reaches the rendition service through a load balancer, a reverse proxy or a firewall, that component will close idle connections without telling either side. With `max.idle.time` left at `-1` the pool never recycles, so it hands out connections the other end has already dropped. The symptom is a request that stalls for exactly the idle-timeout duration and then succeeds on retry, and under sustained load the pool fills with dead connections.
+
+Set `max.idle.time` below the shortest idle timeout on the path. For a 60 second load balancer timeout, `arender.server.rendition.rest.max.idle.time=30000` with `arender.server.rendition.rest.max.life.time=300000` is a sound starting point.
+:::
+
+Two points worth knowing:
+
+- The ARender HMI has its own pool with the same defaults, configured in ARender's own files. If the viewer and thumbnails traverse the same load balancer, set `arender.server.rendition.rest.max.idle.time` there too.
+- Do not confuse this namespace with `rest.client.*`, which configures the rendition broker's outgoing calls to its microservices and belongs on the broker, not on Core.
 
 # Security headers
 

--- a/src/generated/flowerDocsReleases.json
+++ b/src/generated/flowerDocsReleases.json
@@ -2,9 +2,9 @@
   {
     "version": "2026.1.0",
     "majorVersion": "2026",
-    "date": "2026-07-24",
+    "date": "2026-07-28",
     "description": "FlowerDocs 2026.1.0 is a consolidation release improving reliability of search, CSV export, column management, virtual folder display in ARender, and document versioning.",
-    "hasUpgradeNotes": false,
+    "hasUpgradeNotes": true,
     "slug": "2026.1.0",
     "latest": true
   },

--- a/src/pages/release-note/flowerdocs/2026.0.0/upgrade-notes.md
+++ b/src/pages/release-note/flowerdocs/2026.0.0/upgrade-notes.md
@@ -1,13 +1,14 @@
 ---
 title: Upgrade Notes 2026.0.0
 description: Upgrade Notes 2026.0.0
+toc_max_heading_level: 4
 ---
 
 # Upgrade notes 2026.0.0
 
-# Version upgrade
+## Version upgrade
 
-## Upgrading from 2025.x.x
+### Upgrading from 2025.x.x
 
 Direct upgrade is supported, you will need to follow the plan :
 
@@ -17,7 +18,7 @@ Direct upgrade is supported, you will need to follow the plan :
 4. Update systemd services if use them (see [Launch](/docs/flowerdocs/install/start))
 5. Start all applications with their prerequisites
 
-## Upgrading from versions 2.7.x and 2.8.x
+### Upgrading from versions 2.7.x and 2.8.x
 
 Upgrades from versions 2.7 or 2.8 to 2026.0.0 must follow the follow plan:
 
@@ -27,7 +28,7 @@ Upgrades from versions 2.7 or 2.8 to 2026.0.0 must follow the follow plan:
 4. Update systemd services if use them (see [Launch](/docs/flowerdocs/install/start))
 5. Start all applications with their prerequisites
 
-# Prerequisite
+## Prerequisite
 
 See the [Prerequisites](/docs/flowerdocs/install/prerequisites) page for the full requirements.
 
@@ -41,9 +42,9 @@ See the [Prerequisites](/docs/flowerdocs/install/prerequisites) page for the ful
 | Operating system locale | UTF-8 was enforced applicatively | UTF-8 (the application now fails to start if `file.encoding` is not UTF-8) |
 | FlowerDocs Starter Client base | SpringBoot 2.7.18 | Spring Boot 4.0.6 |
 
-# Architecture
+## Architecture
 
-## Removed components
+### Removed components
 
 * **SOAP web services :** The `/services` endpoint, all WSDL/XSD descriptors, `flower-docs-ws-api` and `flower-docs-ws-client` modules are removed. Any third-party integration consuming `/services/*.wsdl` must migrate to the [REST API](/docs/flowerdocs/apis/core/intro). This includes **Companion**. Existing versions of Companion does not work with 2026 versions. A new version based on REST API will be released soon.
 * **Apache CXF** — the SOAP engine, removed together with the SOAP web services.
@@ -51,7 +52,7 @@ See the [Prerequisites](/docs/flowerdocs/install/prerequisites) page for the ful
 * Spring Boot self-executable JAR layout : Spring Boot 4 does not support this feature anymore. The jar must be explicitly launched with `java -jar`. systemd examples in the [documentation](/docs/flowerdocs/install/start) have been updated to reflect this change.
 * Deprecated **FlowerDocs.jsp** redirect has been removed.
 
-## Modified components
+### Modified components
 
 * **OpenSearch** 1.x → 3.6.0 : a reindex of the data is **mandatory** (see [FlowerDocs 2026 upgrade](/docs/flowerdocs/install/opensearch/os-migrate)). Properties move to `opensearch.*` namespaces (see [Data](#data) and [Configuration](#configuration)).
 * **ARender** 2023.x → 2026.0.1
@@ -60,27 +61,27 @@ See the [Prerequisites](/docs/flowerdocs/install/prerequisites) page for the ful
 * **AWS SDK** v1 → v2
 * **Redis** connection properties move to the `spring.data.redis.*` namespace (see [Configuration](#configuration)).
 
-## Added components
+### Added components
 
 * MixPanel library has been introduced into FlowerDocs GUI. It is enabled by default but can be disabled if needed.
 
-## Deprecated components
+### Deprecated components
 
 * OperationHook has been renamed to RestOperationHandler for naming uniformity. FlowerDocs handle both for the moment. OperationHook will be removed on next major release. We recommend to migrate OperationHook to [RestOperationHandler](/docs/flowerdocs/config/core/operation/handlers/rest-operation-handler)
 
-# Customisation and configuration
+## Customisation and configuration
 
-## Configuration {#configuration}
+### Configuration {#configuration}
 
 The full Core property reference is on the [Core configuration](/docs/flowerdocs/install/config/core-config) page.
 
-### Configuration properties to remove
+#### Configuration properties to remove
 
 * All `zuul.*` properties
 * JVM Param `-Xverify:none` — removed in JDK 25 and rejected at startup.
 * JVM Param `-Dflower.docs.core.addon=classpath:flower-docs-services-drools.xml` — the standalone Drools services add-on file no longer exists
 
-### Replaced configuration properties
+#### Replaced configuration properties
 
 | Removed | Replacement |
 | :---- | :---- |
@@ -95,40 +96,38 @@ The full Core property reference is on the [Core configuration](/docs/flowerdocs
 
 *Some other properties may have changed due to the Spring major upgrade.*
 
-## Product
-
-### Technical changes
+### Product
 
 #### Security
 
 * Improvements to FlowerDocs security have been made by upgrading library versions and internal behaviours. This proactive approach ensures better protection against vulnerabilities.
 
-### Behaviour changes
+#### Behaviour changes
 
-#### Performance
+##### Performance
 
 * Cache management has been improved for user and groups to enhance performance and synchronization with LDAP.
 * 2026.0.0 ships explicit pool and timeout settings tuned to better handle workload. Several **defaults changed** versus 2025. Adding timeout avoids hanging thread if resource is not available.
 
-#### Functional
+##### Functional
 
 * Creating or updating a component with two tags of the same name is now rejected with the functional error `F00040` (previously the duplicate was silently removed).
 
-#### Exploitation
+##### Exploitation
 
 * `FileEncodingForcer` — replaced by a UTF-8 verification at startup; the application fails fast if the JVM is not running in UTF-8.
 * Security headers have been hardened (see [Security headers](/docs/flowerdocs/install/config/core-config#security-headers)). If you need customisation about them, feel free to ask the support team.
 * **Production-ready Docker images** : the Docker images have been hardened to be more secure and more configurable.
 * CLM CLI commands renamed (space-separated → hyphenated) to uniformize naming: `string encrypt` → `string-encrypt`, `string decrypt` → `string-decrypt`, `dir analyze` → `dir-analyze`, `dir encrypt` → `dir-encrypt`. The directory commands are documented in [directory encryption](/docs/flowerdocs/config/core/securite/files).
 
-### Delete
+#### Delete
 
 * **Legacy Camunda `ScriptOperationHandler` class-name remap removed**. The 2025 transitional fallback that silently rewrote `com.flower.docs.bpm.core.operation.ScriptOperationHandler` to `com.flower.docs.core.tsp.operation.script.ScriptOperationHandler` is gone. Update any remaining `handler` tags or they will fail at handler resolution (see [Script handler](/docs/flowerdocs/config/core/operation/handlers/script)).
 * Custom cookie serializer for handling SameSite cookie attribute has been deleted as SpringBoot now handles it correctly. You can remove `gui.custom.cookie.serializer.enabled` safely.
 
-## API
+### API
 
-### Behaviour changes {#behaviour-changes-1}
+#### Behaviour changes {#behaviour-changes-1}
 
 * FlowerDocs Starter Client now communicates using REST instead of SOAP with FlowerDocs Core.
 * FlowerDocs Starter Client now uses a dedicated `FlowerDocsObjectMapper` instead of the one provided by SpringBoot. It allows us to provide our own Mixins to have a correct communication between all applications in the FlowerDocs ecosystem.
@@ -143,20 +142,18 @@ The full Core property reference is on the [Core configuration](/docs/flowerdocs
 * Full text search now supports the `-` character.
 * After using the rename endpoint, if the previous file had an extension, it will be restored on the new name.
 
-### Additions
+#### Additions
 
 * `POST /core/rest/acl/reference` — added (FD-17803), see [Managing ACLs](/docs/flowerdocs/apis/core/examples/acl); it **replaces** the now-removed `GET /core/rest/acl/{category}/{id}` route.
 * `POST /core/rest/reservation/reserve`, `POST /core/rest/reservation/release` and `POST /core/rest/reservation`, which replace the per-category endpoints for more flexibility (see [Reserve components](/docs/flowerdocs/apis/core/examples/reservation)).
 * Annotation endpoints now support only JSON. Previously you could provide XML and JSON based on the `Content-Type` / `Accept` HTTP headers.
 
-### Removals
-
-#### Libraries
+#### Removed libraries
 
 * `flower-docs-ws-client` and `flower-docs-ws-api`, used for SOAP only.
 * `flower-docs-demo-center`, which was only used internally.
 
-#### Endpoints
+#### Removed endpoints
 
 * All SOAP endpoints. Need to be replaced by their REST alternative.
 * `PingRestController` (Java \+ endpoint), should use `/core/actuator/status`.
@@ -167,24 +164,24 @@ The full Core property reference is on the [Core configuration](/docs/flowerdocs
 * CSV export endpoints `?async=false` has been removed as we can now handle > 10,000 results, it does not make sense.
 * The cross-category search endpoint exposed under the CSV Export has been removed (it should never have existed).
 
-#### Methods
+#### Removed methods
 
 * `ComponentClassDAO.setActive(...)`, `ComponentClassDAO.getAllVersions(...)`
 
-#### Miscellaneous
+#### Other removals
 
 * Error code `T01789`
 * `InternalFeatures.ES_TYPE`
 
-# Data {#data}
+## Data {#data}
 
-## Required data migration
+### Required data migration
 
 A reindex from OpenSearch 1.x to OpenSearch 3.6.0 is required because the internal engines are not compatible.
 
 A dedicated migration tool ships with this version. See [FlowerDocs 2026 upgrade](/docs/flowerdocs/install/opensearch/os-migrate) for the full procedure.
 
-## Additions
+### Additions
 
 To prepare future evolutions about retention :
 
@@ -192,7 +189,7 @@ To prepare future evolutions about retention :
 * ComponentData has now `operationalRetentionPeriod`, `legalRetentionPeriod` and `retentionType` attributes.
 * New enum RetentionType : Automatic / Manual.
 
-## Removals
+### Removals
 
 * Properties that are no longer used, stored on domain objects coming from a previous FlowerDocs version, have been removed:
   * `Scope.organisationalUnit`
@@ -203,7 +200,9 @@ To prepare future evolutions about retention :
   * `Task.processId`
   * `Task.files`
 
-# FlowerDocs GEC
+## FlowerDocs GEC
+
+### Modified configuration documents
 
 The configuration `gec-creationShortcuts.js` has been modified to drop the trailing slash in REST calls in accordance with Spring Boot 4 specifications which no longer tolerate trailing slashes for endpoints that do not end with one.
 
@@ -213,14 +212,20 @@ The following templates have been modified :
 * `ForInformationMailTemplateConfiguration.html`
 * `AssignationMailTemplateConfiguration.html`.
 
+### Deployment
+
 Deployment documentation included in the client package has been updated with new installation prerequisites for this version.
 
-# FlowerDocs e-Process
+## FlowerDocs e-Process
+
+### Modified configuration documents
 
 The following templates have been modified :
 
 * `BodyTemplate.html`
 * `EnvAssignationMailTemplate.html`
+
+### Removals
 
 Two features have been deleted
 
@@ -230,14 +235,13 @@ Two features have been deleted
     * `export.answer.enable`
     * `export.scope.enable`
     * `export.file.path.enable`
-
-
-
 * The external access. This induced removal  of :
   * `SOL_CompteExterne` tag
   * `EnvAccountCreation` process
   * `Associated ACL_ENV_Account` security
   * `ENV_MesEnveloppesExternes` virtual folder class
+
+### Deployment
 
 Deployment documentation included in the client package has been updated with new installation prerequisites for this version.
 

--- a/src/pages/release-note/flowerdocs/2026.1.0/_index.md
+++ b/src/pages/release-note/flowerdocs/2026.1.0/_index.md
@@ -3,6 +3,6 @@ title: "2026.1.0"
 ARenderVersion: 2026.1.0
 RedisVersion: 8.8
 OSVersion: 3.6.0
-ReleaseDate: 24/07/2026
+ReleaseDate: 28/07/2026
 StartPage: release-notes
 ---

--- a/src/pages/release-note/flowerdocs/2026.1.0/release-notes.md
+++ b/src/pages/release-note/flowerdocs/2026.1.0/release-notes.md
@@ -122,7 +122,7 @@ Documents added from Companion in eProcess solutions can now be indexed immediat
 
 #### **💻 History**
 
-In the solution templates: the `classid` technical field is now consistently set on tasks during unassignment, ensuring the task class's custom icon displays reliably in the history. No impact on users. 
+In eProcess: the `classid` technical field is now set on the facts created when a task is answered, cancelled or adjourned, ensuring the task class's custom icon displays reliably in the history. No impact on users. 
 
 #### ⚙️ **Customization banner**
 

--- a/src/pages/release-note/flowerdocs/2026.1.0/release-notes.md
+++ b/src/pages/release-note/flowerdocs/2026.1.0/release-notes.md
@@ -159,7 +159,7 @@ Documents added from Companion in GEC solutions can now be indexed immediately: 
 
 #### **💻 History**
 
-In FlowerDocs GEC: the `classid` technical field is now consistently set on tasks created during mail copying or routing, ensuring the custom icon for GEC task classes displays reliably in the history. No impact on users. 
+In FlowerDocs GEC: the `classid` technical field is now set on the facts created when a mail is copied or routed, ensuring the custom icon for GEC task classes displays reliably in the history. No impact on users. 
 
 #### ⚙️ **Customization banner**
 

--- a/src/pages/release-note/flowerdocs/2026.1.0/release-notes.md
+++ b/src/pages/release-note/flowerdocs/2026.1.0/release-notes.md
@@ -22,23 +22,23 @@ This version requires the following software prerequisites:
 
 <br />
 
-## **Overview**
+## Overview
 
 FlowerDocs 2026.1.0 is a consolidation release. It improves the reliability of search, CSV export, column management, virtual folder display in ARender, and document versioning. It also removes the Lasso feature, hidden by default since version 2025.4.0, and includes an ARender update to version 2026.1.0.
 
-## **Upgrade Notes**
+## Upgrade Notes
 
 The major technical changes in this version are detailed in the upgrade notes available [here](../upgrade-notes)
 
-## **For users**
+## For users
 
 This release focuses on day-to-day reliability, with improvements to search (quick search, saved searches, and pagination), CSV export, column management, virtual folder display in ARender, and annotations. See the fixes below for details.
 
-#### **💻 Removal of the Lasso feature**
+#### 💻 Removal of the Lasso feature
 
 The Lasso feature, hidden by default since version 2025.4.0 and no longer in use, has been removed from the product.
 
-#### **💻 ARender viewer update**
+#### 💻 ARender viewer update
 
 The ARender viewer embedded in FlowerDocs has also been updated to version 2026.1.0. This update resolves several issues:
 
@@ -50,33 +50,33 @@ The ARender viewer embedded in FlowerDocs has also been updated to version 2026.
 
 For more information, see the ARender release notes [here](/release-note/arender/v2026.1.0/release-notes)
 
-## **For integrators**
+## For integrators
 
-#### **💻 Technical fixes**
+#### 💻 Technical fixes
 
 Several technical fixes have also been made to the Swagger interface, visual customization, and redirect error messages, see the fixes below for details.
 
-## **For operators**
+## For operators
 
-#### **💻 Security**
+#### 💻 Security
 
 Several CVEs have been addressed in this version. Specific details are withheld to protect against exploit attempts. 
 
-#### **💻 Logging**
+#### 💻 Logging
 
 A warning message is now added to the application logs when a FlowerDocs instance is used over HTTP rather than HTTPS, to help operations teams identify insecure configurations.
 
-#### **💻 Migration tool for 2026**
+#### 💻 Migration tool for 2026
 
 The migration tool for upgrading from 2025 to 2026 is now functional in AWS environments using managed services. See the documentation for the detailed procedure.
 
-#### **💻 ARender update : performance and security**
+#### 💻 ARender update : performance and security
 
 The update to ARender 2026.1.0 also reduces resource consumption on the rendition server, thanks to the default deactivation of a Spring Security observation mechanism that had become unnecessarily costly since the migration to Spring Boot 4\. This same ARender update also includes its own set of security fixes and Docker image updates following the continuous analysis of its third-party dependencies.
 
 For more information, see the ARender release notes [here](/release-note/arender/v2026.1.0/release-notes)
 
-## **Bug fixes**
+## Bug fixes
 
 
 | Bug | Ticket |
@@ -102,74 +102,74 @@ For more information, see the ARender release notes [here](/release-note/arender
 | Versioning — For document classes configured with manual versioning, adding new content now correctly removes the old file from storage (S3 or file system).  |  |
 | Documents — File handles and connections are no longer leaked when reading document content. |  |
 
-## **Known issues**
+## Known issues
 
 *No known issues specific to FlowerDocs for this version.*
 
 ---
 
-## **FlowerDocs eProcess**
+## FlowerDocs eProcess
 
-### **For users**
+### For users
 
 No specific changes have been made to eProcess beyond the above. This version benefits from all the improvements and fixes made to FlowerDocs for users.
 
-### **For integrators**
+### For integrators
 
-#### **💻 Companion**
+#### 💻 Companion
 
 Documents added from Companion in eProcess solutions can now be indexed immediately: the indexing form, which previously failed to appear, now appears correctly.
 
-#### **💻 History**
+#### 💻 History
 
 In eProcess: the `classid` technical field is now set on the facts created when a task is answered, cancelled or adjourned, ensuring the task class's custom icon displays reliably in the history. No impact on users. 
 
-#### ⚙️ **Customization banner**
+#### ⚙️ Customization banner
 
 Custom banner color now works correctly through the intended CSS variable, without needing to add `!important`. This concerns integrators who customize branding and is not noticeable to end users. 
 
-### **For operators**
+### For operators
 
 No specific changes have been made to eProcess. This version benefits from all the improvements and fixes made to FlowerDocs for operators.
 
-### **Bug fixes**
+### Bug fixes
 
 | Bug | Ticket |
 | ----- | ----- |
 | **Integrators** |  |
 | Companion — The indexing form now appears correctly when adding a document from Companion, allowing it to be indexed immediately. | BUSOL-534 |
 
-### **Known issues**
+### Known issues
 
 *No known issues specific to eProcess for this version.*
 
 ---
 
-## **FlowerDocs GEC**
+## FlowerDocs GEC
 
-### **For users**
+### For users
 
 No specific changes have been made to GEC beyond the above. This version benefits from all the improvements and fixes made to FlowerDocs for users.
 
-### **For integrators**
+### For integrators
 
-#### **💻 Companion**
+#### 💻 Companion
 
 Documents added from Companion in GEC solutions can now be indexed immediately: the indexing form, which previously failed to appear, now appears correctly.
 
-#### **💻 History**
+#### 💻 History
 
 In FlowerDocs GEC: the `classid` technical field is now set on the facts created when a mail is copied or routed, ensuring the custom icon for GEC task classes displays reliably in the history. No impact on users. 
 
-#### ⚙️ **Customization banner**
+#### ⚙️ Customization banner
 
 Custom banner color now works correctly through the intended CSS variable, without needing to add `!important`. This concerns integrators who customize branding and is not noticeable to end users. 
 
-### **For operators**
+### For operators
 
 No specific changes have been made to GEC. This version benefits from all the improvements and fixes made to FlowerDocs for operators.
 
-### **Bug fixes**
+### Bug fixes
 
 | Bug | Ticket |
 | ----- | ----- |
@@ -178,7 +178,7 @@ No specific changes have been made to GEC. This version benefits from all the im
 | **Integrators** |  |
 | Companion — The indexing form now appears correctly when adding a document from Companion, allowing it to be indexed immediately. | BUSOL-534 |
 
-### **Known issues**
+### Known issues
 
 *No known issues specific to GEC for this version.*
 

--- a/src/pages/release-note/flowerdocs/2026.1.0/release-notes.md
+++ b/src/pages/release-note/flowerdocs/2026.1.0/release-notes.md
@@ -28,7 +28,7 @@ FlowerDocs 2026.1.0 is a consolidation release. It improves the reliability of s
 
 ## **Upgrade Notes**
 
-The major technical changes in this version are detailed in the upgrade notes available [here](https://doc.uxopian.com/release-note/flowerdocs/2026.1.0/upgrade-notes/). 
+The major technical changes in this version are detailed in the upgrade notes available [here](../upgrade-notes)
 
 ## **For users**
 
@@ -48,7 +48,7 @@ The ARender viewer embedded in FlowerDocs has also been updated to version 2026.
 * Downloading several documents with identical names into a single archive no longer causes an error.  
 * PDF versions of emails can now also display headers in German, in addition to French and English.
 
-For more information, see the ARender release notes [here](https://doc.uxopian.com/release-note/arender/v2026.1.0/release-notes/).
+For more information, see the ARender release notes [here](/release-note/arender/v2026.1.0/release-notes)
 
 ## **For integrators**
 
@@ -74,7 +74,7 @@ The migration tool for upgrading from 2025 to 2026 is now functional in AWS envi
 
 The update to ARender 2026.1.0 also reduces resource consumption on the rendition server, thanks to the default deactivation of a Spring Security observation mechanism that had become unnecessarily costly since the migration to Spring Boot 4\. This same ARender update also includes its own set of security fixes and Docker image updates following the continuous analysis of its third-party dependencies.
 
-For more information, see the ARender release notes [here](https://doc.uxopian.com/release-note/arender/v2026.1.0/release-notes/).
+For more information, see the ARender release notes [here](/release-note/arender/v2026.1.0/release-notes)
 
 ## **Bug fixes**
 

--- a/src/pages/release-note/flowerdocs/2026.1.0/release-notes.md
+++ b/src/pages/release-note/flowerdocs/2026.1.0/release-notes.md
@@ -84,6 +84,8 @@ For more information, see the ARender release notes [here](/release-note/arender
 | **Users** |  |
 | CSV Export — Column headers corresponding to native technical tags are now correctly translated when the interface language is set to French. |  |
 | CSV Export — A column added via a filter clause is now correctly included in the exported file. |  |
+| CSV Export — The exported file is now correctly recognised as a CSV file when the search contains a multi-valued criterion. |  |
+| CSV Export — The exported file now contains only the columns displayed in the interface. |  |
 | Columns — The "Assign To" tag is no longer incorrectly displayed as a default column, in line with the defined configuration. |  |
 | Interface — Icon alignment for instance title actions has been fixed. | FD-17037 / TMAFLW-1066 |
 | Search — A search containing only a quick-search criterion can now be saved, and a saved search of this type can now be edited. | FD-18286 / FD-15446 / TMAFLW-261 |
@@ -98,6 +100,7 @@ For more information, see the ARender release notes [here](/release-note/arender
 | **Operators** |  |
 | Administration — A warning message is now added to the logs when FlowerDocs is used over HTTP. |  |
 | Versioning — For document classes configured with manual versioning, adding new content now correctly removes the old file from storage (S3 or file system).  |  |
+| Documents — File handles and connections are no longer leaked when reading document content. |  |
 
 ## **Known issues**
 

--- a/src/pages/release-note/flowerdocs/2026.1.0/upgrade-notes.md
+++ b/src/pages/release-note/flowerdocs/2026.1.0/upgrade-notes.md
@@ -1,0 +1,121 @@
+---
+title: Upgrade Notes 2026.1.0
+description: Upgrade Notes 2026.1.0
+toc_max_heading_level: 4
+---
+
+# Upgrade notes 2026.1.0
+
+## Version upgrade
+
+### Upgrading from 2026.0.x
+
+Direct upgrade is supported, you will need to follow the plan :
+
+1. Apply needed modifications after reading this upgrade notes
+2. Upgrade ARender to 2026.1.0
+3. Start all applications with their prerequisites
+
+### Upgrading from 2025.x.x or earlier
+
+Direct upgrade is **not** supported. Upgrades from 2025.x.x or earlier to 2026.1.0 must follow the following plan :
+
+1. Apply the [2026.0.0 upgrade notes](/release-note/flowerdocs/2026.0.0/upgrade-notes) **first, in full**, as well as all upgrade notes between your version and 2026.0.0. They carry the breaking changes of the 2026 major : Spring Boot 4, Jackson 3, the removal of the SOAP web services and the mandatory OpenSearch reindex from 1.x to 3.6.0 (see [FlowerDocs 2026 upgrade](/docs/flowerdocs/install/opensearch/os-migrate))
+2. Then apply this upgrade notes, following the plan above
+
+## Architecture
+
+### Modified components
+
+- **ARender** 2026.0.1 → 2026.1.0
+
+## Customisation and configuration
+
+### Configuration {#configuration}
+
+#### Configuration properties to remove
+
+| Removed         | Replacement                  |
+| :-------------- | :--------------------------- |
+| `lasso.enabled` | none, the feature is removed |
+
+### Product
+
+#### Security
+
+- Improvements to FlowerDocs security have been made by upgrading library versions and internal behaviours. This proactive approach ensures better protection against vulnerabilities.
+
+#### Behaviour changes
+
+##### Functional
+
+- **Task attachment class patterns now require a full match.** A pattern such as `Invoice` used to match `Invoice`, `InvoiceScan` and `ScannedInvoice` ; it now matches `Invoice` only. Use `Invoice.*` or `.*Invoice.*` for partial matching.
+- The `Assign To` tag is no longer part of the **default** task columns, in line with the configured `selectClause` and `filterClauses`. It remains available in the column picker, so users who need it can add it themselves.
+
+##### Exploitation
+
+- **Manual versioning now frees the replaced file.** Replacing a document's content deletes the file it replaced, unless another version still references it. Previously this happened only for classes configured without versioning, so with manual versioning the replaced file was left in storage.
+- **A warning is logged when FlowerDocs is served over plain HTTP**, since a `Secure` cookie is never sent over an unencrypted connection. This is a diagnostic aid for operations teams and changes no behaviour.
+- Two `opensearch-reindex` parameters were removed : `--report-only` → `--dry-run=true`, of which it was only an alias, and `--detailed-report` → nothing, as the per-class breakdown is now produced on every run. A leftover `--detailed-report` is ignored. This only concerns you if the 2025 to 2026 migration is still ahead of you ; the parameters added in this version are documented in [FlowerDocs 2026 upgrade](/docs/flowerdocs/install/opensearch/os-migrate).
+
+#### Removals
+
+- **Lasso feature.** Announced for removal in the [2025.4.0 upgrade notes](/release-note/flowerdocs/2025.4.0/upgrade-notes) and disabled by default since then, it is now removed. Remove the `lasso.enabled` property from your configuration (see [Configuration](#configuration)).
+
+### API
+
+#### Behaviour changes
+
+- **CSV export column headers changed.** Headers corresponding to native technical tags are now translated according to the interface language, and the exported file now contains only the columns displayed in the interface. Both change the content of the generated file. **If you consume the CSV programmatically, check your parsing** : header labels differ per locale and previously-exported columns may no longer be present.
+- **The `Content-Disposition` filename is now quoted.** The ASCII `filename` parameter is wrapped in double quotes, with embedded quotes and backslashes escaped, so a name containing a comma or a space no longer breaks the header. Clients that parse the header by splitting on separators without honouring quoting must be checked.
+- **The search form JavaScript API now initialises on every search.** Previously it stayed uninitialised when no class criterion drove the search form, so `registerForFieldChange` callbacks were never called.
+
+## FlowerDocs GEC
+
+Update the GEC scope with CLM.
+
+### History facts
+
+Facts written by GEC now record **semantic action values** instead of generic ones, and the technical `classid` field they carry has changed so that the expected icon displays in the history.
+
+| Event             | 2026.0.0 | 2026.1.0   |
+| :---------------- | :------- | :--------- |
+| Mail copy         | `CREATE` | `COPY`     |
+| Task unassignment | `UPDATE` | `UNASSIGN` |
+
+:::caution Only new facts are affected
+This applies to facts created from 2026.1.0 onwards, which display with the expected icon. Facts already stored keep their previous action value and continue to display as before.
+:::
+
+### Modified configuration documents
+
+The following configuration documents have been modified :
+
+- `gec-createFactAfterCopyAndDeleteCopy.js`
+- `Unassign_history.js`
+- `solutionStyle.css`
+
+## FlowerDocs eProcess
+
+Update the eProcess scope with CLM.
+
+### History facts
+
+Facts written by eProcess now record **semantic action values** instead of generic ones, and the technical `classid` field they carry has changed so that the expected icon displays in the history.
+
+| Event                                         | 2026.0.0 | 2026.1.0   |
+| :-------------------------------------------- | :------- | :--------- |
+| Task answer, cancellation reason, adjournment | `UPDATE` | `ANSWER`   |
+| Task unassignment                             | `UPDATE` | `UNASSIGN` |
+
+:::caution Only new facts are affected
+This applies to facts created from 2026.1.0 onwards, which display with the expected icon. Facts already stored keep their previous action value and continue to display as before.
+:::
+
+### Modified configuration documents
+
+The following configuration documents have been modified :
+
+- `env-CreateAjournerFact.js`
+- `Unassign_history.js`
+- `solutionStyle.css`


### PR DESCRIPTION
Upgrade notes for 2026.1.0, scoped from the release triage sheet (column L for inclusion, column M for wording).

Heading levels restructured in both 2026.0.0 and 2026.1.0 so sections appear in the table of contents. Docusaurus renders H2 to H3 and its minimum level is 2, so the previous convention of one `#` per section hid every section title. Now a single H1 for the page title, sections at H2, and `toc_max_heading_level: 4`. For 2026.0.0 this is headings and frontmatter only, no prose change, plus subsections for GEC and e-Process.

Three bug fixes added to the 2026.1.0 release notes (FD-18519, FD-18545, FD-18547), which were Done with this fix version but had no triage row.

Also: relative links in the 2026.1.0 release notes, release date 28/07/2026, and `hasUpgradeNotes` enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
