### PR TITLE
FD-18516 MCP server release notes target 2026.1.0-ft1

### DIFF
--- a/docs/flowerdocs/connecteurs/mcp/release-notes.md
+++ b/docs/flowerdocs/connecteurs/mcp/release-notes.md
@@ -9,7 +9,7 @@ import FlowerDocsMcpDownload from '@site/src/components/FlowerDocsMcpDownload';
 
 # FlowerDocs MCP Server Release Notes
 
-## 2026.1.0-ft0
+## 2026.1.0-ft1
 
 ### 💡 Overview
 
@@ -23,7 +23,7 @@ For installation and configuration, see the [MCP Server documentation](../gettin
 
 | | |
 |---|---|
-| Server version | 2026.1.0-ft0 |
+| Server version | 2026.1.0-ft1 |
 | Compatible FlowerDocs versions | 2026.0.0 and later versions of the 2026 line |
 | MCP protocol revision | 2025-11-25 (latest; earlier revisions down to 2024-11-05 negotiated for compatibility) |
 | Transport | Streamable HTTP (`/mcp`) |
@@ -73,4 +73,4 @@ At startup, the server checks that FlowerDocs Core is reachable and keeps retryi
 
 None known at this release.
 
-<FlowerDocsMcpDownload version="2026.1.0-ft0" />
+<FlowerDocsMcpDownload version="2026.1.0-ft1" />


### PR DESCRIPTION
ft0 was internal only, so the first published MCP server version is ft1.

Updates the three places the version appears in `docs/flowerdocs/connecteurs/mcp/release-notes.md`: the section heading, the "Server version" row of the compatibility table, and the `FlowerDocsMcpDownload` component, which builds the Artifactory URL from it.

Consistent with `flower-templates`, which already pins `flowerdocs.mcp.version = 2026.1.0-ft1-SNAPSHOT`.

The ft1 jar is being released now. Until it lands in `arondor-release` the Download and Sha256 buttons on that page will 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
