### PR TITLE
FD-18516 document the uxodocs documentation MCP pairing

### DIFF
--- a/docs/flowerdocs/connecteurs/mcp/documentation-mcp.md
+++ b/docs/flowerdocs/connecteurs/mcp/documentation-mcp.md
@@ -1,0 +1,46 @@
+---
+title: Documentation MCP
+sidebar_position: 3
+date: "2026-07-29T21:30:00+02:00"
+description: "Pair the FlowerDocs MCP server with the uxodocs documentation MCP so the assistant writes configurations that are actually correct."
+---
+
+# Pair the MCP server with the documentation
+
+The FlowerDocs MCP server lets an assistant **act** on your instance: create a tag class, write a GUI configuration, deploy a script. It does not teach the assistant **how FlowerDocs is configured**.
+
+That knowledge lives in this documentation. Expose it as a second, read-only MCP server, and the assistant uses both in the same conversation: it reads the page, then applies the configuration.
+
+:::tip Recommended setup
+Two MCP servers: **`flowerdocs`** (holds your credentials, performs the changes) and **`uxodocs`** (read-only, provides the knowledge).
+:::
+
+## Why it is a real gain
+
+`technicaldoc_describe` returns a **field schema**, not a grammar. For a GUI configuration it says there is a `fileContent` field holding XML. It does not say which beans, which attributes, or which values FlowerDocs expects inside.
+
+Without the documentation, the assistant fills that gap from memory. FlowerDocs configuration is a product-specific format that no model knows, so the result is plausible and wrong: invented bean names, an `ExecutionPhase` that does not exist, a script calling an API that was never shipped. The tool call succeeds, and the configuration does nothing.
+
+With the documentation MCP, it reads the reference page instead of guessing, and a configuration rejected by Core leads to a correction rather than a blind retry.
+
+## How it works
+
+Asking *"create a search form for invoices with the InvoiceNumber and InvoiceDate fields"* triggers three steps:
+
+1. `technicaldoc_describe("gui_configuration")` on **flowerdocs**: the assistant learns which fields the document takes.
+2. A read of the search form reference on **uxodocs**: it learns the XML structure.
+3. `technicaldoc_create(...)` on **flowerdocs**: the document is created with content that matches the reference, and the GUI cache is purged so the form appears immediately.
+
+The same pattern applies to scripts, operation handlers, CSS, routes and templates.
+
+## Set it up with GitMCP
+
+[GitMCP](https://gitmcp.io) serves a public GitHub repository as a read-only MCP server. This documentation lives in the public [Uxopian/uxodocs](https://github.com/Uxopian/uxodocs) repository, so a single URL exposes it:
+
+```
+https://gitmcp.io/Uxopian/uxodocs
+```
+
+The **uxodocs** entry sits next to **flowerdocs** in the same client configuration file, which [Getting Started](./getting-started.md#connect-your-ai-client) shows in full for Claude Desktop, Claude Code and Cursor.
+
+Nothing to install, no credentials to manage since the repository is public, and it always serves the current documentation.

--- a/docs/flowerdocs/connecteurs/mcp/getting-started.md
+++ b/docs/flowerdocs/connecteurs/mcp/getting-started.md
@@ -4,6 +4,9 @@ sidebar_position: 1
 date: "2026-07-21T09:00:00+02:00"
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # FlowerDocs MCP Server
 
 The FlowerDocs MCP server exposes FlowerDocs **administration and configuration management** as tools that an AI assistant can call, using the [Model Context Protocol](https://modelcontextprotocol.io). Connect any MCP-compatible assistant (Claude Desktop, Claude Code, Cursor, VS Code, and others) and drive FlowerDocs in natural language: create tag classes, edit GUI configurations, manage scripts and operation handlers, purge caches, and more.
@@ -11,7 +14,7 @@ The FlowerDocs MCP server exposes FlowerDocs **administration and configuration 
 It runs as a standalone service alongside your FlowerDocs Core and GUI, and speaks the Model Context Protocol over the Streamable HTTP transport.
 
 :::info It is an administration tool
-Every tool runs under real FlowerDocs user credentials, and the whole server is gated by a shared access key. It is meant for administrators and integrators. See [Authentication](../install#authentication). Do not expose it openly on the internet.
+Every tool runs under real FlowerDocs user credentials, and the whole server is gated by a shared access key. It is meant for administrators and integrators. See [Authentication](./install.md#authentication). Do not expose it openly on the internet.
 :::
 
 ## Prerequisites
@@ -23,9 +26,10 @@ Every tool runs under real FlowerDocs user credentials, and the whole server is 
 
 ## Connect your AI client
 
-Once the server is running (see [Installation](../install)), the MCP endpoint is available at `http://localhost:8086/flowerdocs-mcp/mcp`. Point your client at it and add the required headers.
+Once the server is running (see [Installation](./install.md)), the MCP endpoint is available at `http://localhost:8086/flowerdocs-mcp/mcp`. Declare two servers in your client configuration: **`flowerdocs`**, which performs the changes, and **`uxodocs`**, which gives the assistant this documentation so it gets them right (see [Documentation MCP](./documentation-mcp.md)).
 
-### Claude Desktop
+<Tabs>
+<TabItem value="desktop" label="Claude Desktop" default>
 
 Edit `claude_desktop_config.json` (**Windows**: `%APPDATA%\Claude\`, **Mac**: `~/Library/Application Support/Claude/`):
 
@@ -41,14 +45,19 @@ Edit `claude_desktop_config.json` (**Windows**: `%APPDATA%\Claude\`, **Mac**: `~
         "--header", "X-FlowerDocs-Password: ENC(yourEncryptedPassword)",
         "--header", "X-FlowerDocs-Scope: FD"
       ]
+    },
+    "uxodocs": {
+      "command": "mcp-remote",
+      "args": ["https://gitmcp.io/Uxopian/uxodocs"]
     }
   }
 }
 ```
 
-`mcp-remote` bridges URL-based MCP servers for Claude Desktop; install it with `npm install -g mcp-remote`. Restart Claude Desktop; **flowerdocs** appears as a connected server.
+`mcp-remote` bridges URL-based MCP servers for Claude Desktop; install it with `npm install -g mcp-remote`. Restart Claude Desktop; both servers appear as connected.
 
-### Claude Code
+</TabItem>
+<TabItem value="code" label="Claude Code">
 
 Add to `.mcp.json` in your project (or `~/.claude/.mcp.json`):
 
@@ -64,14 +73,19 @@ Add to `.mcp.json` in your project (or `~/.claude/.mcp.json`):
         "X-FlowerDocs-Password": "ENC(yourEncryptedPassword)",
         "X-FlowerDocs-Scope": "FD"
       }
+    },
+    "uxodocs": {
+      "type": "url",
+      "url": "https://gitmcp.io/Uxopian/uxodocs"
     }
   }
 }
 ```
 
-Launch Claude Code; the server connects automatically.
+Launch Claude Code; both servers connect automatically.
 
-### Other MCP clients
+</TabItem>
+<TabItem value="other" label="Cursor and others">
 
 Any MCP-compatible client works, since the server speaks the standard Streamable HTTP transport. Point the client at the same URL and pass the same four headers. For example, in Cursor (`.cursor/mcp.json`):
 
@@ -86,12 +100,20 @@ Any MCP-compatible client works, since the server speaks the standard Streamable
         "X-FlowerDocs-Password": "ENC(yourEncryptedPassword)",
         "X-FlowerDocs-Scope": "FD"
       }
+    },
+    "uxodocs": {
+      "url": "https://gitmcp.io/Uxopian/uxodocs"
     }
   }
 }
 ```
 
-The same applies to other MCP-capable assistants (VS Code, Cline, and similar). To browse and call the tools interactively without an assistant, use the [MCP Inspector](https://github.com/modelcontextprotocol/inspector), selecting the **Streamable HTTP** transport and the URL above.
+The same applies to other MCP-capable assistants (VS Code, Cline, and similar).
+
+</TabItem>
+</Tabs>
+
+To browse and call the tools interactively without an assistant, use the [MCP Inspector](https://github.com/modelcontextprotocol/inspector), selecting the **Streamable HTTP** transport and the URL above.
 
 ## Try it out
 
@@ -122,6 +144,8 @@ The tools are grouped into families:
 
 Each tool is advertised with `readOnly` / `destructive` hints, so a client such as Claude Desktop groups read-only tools apart from a **Write / delete tools** group and can ask for confirmation before running the destructive ones.
 
-## Pair it with the documentation
+## Why the second server matters
 
-Tool descriptions are intentionally minimal to keep the token budget small. For the assistant to produce correct XML, script APIs or operation-handler configurations, give it access to this FlowerDocs documentation through a companion MCP server (a filesystem or GitHub MCP pointed at the docs). The assistant then combines both: it discovers a field schema with `technicaldoc_describe`, reads the matching documentation page, and writes the document with `technicaldoc_create`.
+Tool descriptions are intentionally minimal: `technicaldoc_describe` tells the assistant that a GUI configuration holds XML, not which XML FlowerDocs expects. The **uxodocs** entry closes that gap, so the assistant reads the reference page before writing the document instead of guessing its structure.
+
+See [Documentation MCP](./documentation-mcp.md) for what that changes in practice.

--- a/docs/flowerdocs/connecteurs/mcp/install.md
+++ b/docs/flowerdocs/connecteurs/mcp/install.md
@@ -10,7 +10,7 @@ The MCP server is a standalone Spring Boot service. It ships as a JAR and a Dock
 
 ## Get the server
 
-- **JAR**: the latest `flower-docs-mcp-server.jar`, available from the [release notes](../release-notes).
+- **JAR**: the latest `flower-docs-mcp-server.jar`, available from the [release notes](./release-notes.md).
 - **Docker**: the delivered `flower-docs-mcp-server` image (exposes port `8086`, with a built-in `HEALTHCHECK`).
 
 ## Configure it
@@ -89,5 +89,5 @@ curl -X POST http://localhost:8086/flowerdocs-mcp/encrypt \
 A Swagger UI is served at `/flowerdocs-mcp/swagger-ui/index.html`: enter the access key and the value to encrypt, and copy the `ENC(...)` result.
 
 :::warning Bootstrapping the access key
-`/encrypt` is itself gated by the access key, so you cannot use it to encrypt the access key the first time. Produce that first `ENC(...)` value out-of-band. See [Encrypting a character string](../../../apis/core/examples/stringEncryptor) or the [CLM documentation](../../../install/clm/clm).
+`/encrypt` is itself gated by the access key, so you cannot use it to encrypt the access key the first time. Produce that first `ENC(...)` value out-of-band. See [Encrypting a character string](../../apis/core/examples/stringEncryptor.md) or the [CLM documentation](../../install/clm/clm.md).
 :::

--- a/docs/flowerdocs/connecteurs/mcp/release-notes.md
+++ b/docs/flowerdocs/connecteurs/mcp/release-notes.md
@@ -1,6 +1,6 @@
 ---
 title: Release Notes
-sidebar_position: 3
+sidebar_position: 4
 description: "First release of the FlowerDocs MCP Server: 26 tools for administration, configuration components and technical documents, per-user authentication, and an independent release train."
 date: "2026-07-21T09:00:00+02:00"
 ---
@@ -17,7 +17,7 @@ The FlowerDocs MCP Server gives access to FlowerDocs configuration, creating tag
 
 This is its first release note. The server has its own fast-track release train, independent from FlowerDocs, and may be updated between FlowerDocs releases.
 
-For installation and configuration, see the [MCP Server documentation](../getting-started).
+For installation and configuration, see the [MCP Server documentation](./getting-started.md).
 
 ### 🔌 Compatibility
 


### PR DESCRIPTION
## Summary

Documents the **documentation MCP** pairing, which the FlowerDocs MCP server README recommends but the published documentation never mentioned: alongside the `flowerdocs` server, an assistant should also be given a read-only `uxodocs` server so it reads the reference pages instead of inventing FlowerDocs XML.

## Changes

**New page** `docs/flowerdocs/connecteurs/mcp/documentation-mcp.md` (Documentation MCP, `sidebar_position: 3`)

- Why the pairing matters: `technicaldoc_describe` returns a field schema, not the XML grammar, so without a documentation source the assistant fills the gap from memory and produces configurations that are plausible, accepted, and inert.
- How it works: the describe → read reference → create sequence.
- Setup with [GitMCP](https://gitmcp.io) serving the public `Uxopian/uxodocs` repository, a single URL, no install and no credentials.

**Getting Started**

- `Connect your AI client` now uses tabs (Claude Desktop / Claude Code / Cursor and others) instead of three stacked sections, and every snippet declares both servers, `flowerdocs` and `uxodocs`, so the client configuration is documented once, here.
- The MCP Inspector note moved out of the Cursor block so it applies to every client.
- `Pair it with the documentation` became `Why the second server matters`: the rationale in two sentences plus a link, no duplicated configuration.

**Release notes**: `sidebar_position` 3 → 4, to keep the release notes last after the new page.

## Broken relative links fixed

The MCP pages used extension-less relative links (`../install`, `./install`). With `trailingSlash: true` those are resolved by the browser against the current URL, so they only worked on one of the two URL forms of a page, and `../` climbed out of the `mcp/` folder entirely. All of them now use the `.md` form, which Docusaurus resolves at build time into an absolute permalink:

| File | Was | Now |
|---|---|---|
| `getting-started.md` | `../install#authentication`, `../install` | `./install.md#authentication`, `./install.md` |
| `install.md` | `../release-notes` | `./release-notes.md` |
| `install.md` | `../../../apis/core/examples/stringEncryptor`, `../../../install/clm/clm` | `../../apis/core/examples/stringEncryptor.md`, `../../install/clm/clm.md` |
| `release-notes.md` | `../getting-started` | `./getting-started.md` |

Note for later: `onBrokenLinks` and `onBrokenMarkdownLinks` are both set to `warn`, which is why these never failed a build. Other pages in the repo may carry the same pattern.

## Test plan

- [x] `npm start` compiles with no MDX error, all four pages return 200
- [x] Sidebar order under MCP Server: Getting Started, Installation, Documentation MCP, Release Notes
- [x] Client tabs switch correctly on both pages that use them
- [x] Every corrected link verified in the browser on the trailing-slash URL form, all targets return 200
- [x] `npx prettier --check` passes on the four files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
