### PR TITLE
Promote to production: modern ARender doc layout on archived v2026 versions

### DIFF
--- a/src/css/arender.css
+++ b/src/css/arender.css
@@ -420,10 +420,13 @@
    UXODOCS LAYOUT OVERRIDES
    ================================================================ */
 
-/* Hide secondary nav on the v2026 (current) ARender doc layout — redundant with
-   the sidebar there. Older versioned docs (v2023.x) still rely on the secondary
-   nav to surface their top-level categories. */
-[class*="plugin-id-arender"][class*="docs-version-current"] .secondary-nav--arender {
+/* Hide the secondary nav on the modern ARender doc layout: the current version
+   AND every v2026+ snapshot, where it is redundant with the vertical sidebar.
+   Only the legacy versioned docs (v4, v2023.x) still rely on the secondary nav
+   to surface their top-level categories, so we exclude those explicitly rather
+   than gating on docs-version-current (which drops off a version the moment a
+   newer one is released). */
+[class*="plugin-id-arender"]:not([class*="docs-version-v4"]):not([class*="docs-version-v2023"]) .secondary-nav--arender {
     display: none;
 }
 
@@ -474,11 +477,12 @@
     margin: 0;
 }
 
-/* On the v2026 (current) ARender layout the secondary nav is hidden, so we
-   undo its sidebar-filtering side effect to keep all top-level items visible.
-   Versioned docs (v2023.x) still use the secondary nav and rely on this
-   filtering to scope the sidebar to the active category. */
-[class*="plugin-id-arender"][class*="docs-version-current"] .uxo-hidden-by-filter {
+/* On the modern ARender layout (current + all v2026+ snapshots) the secondary
+   nav is hidden, so we undo its sidebar-filtering side effect to keep all
+   top-level items visible. Only legacy versioned docs (v4, v2023.x) still use
+   the secondary nav and rely on this filtering to scope the sidebar to the
+   active category. */
+[class*="plugin-id-arender"]:not([class*="docs-version-v4"]):not([class*="docs-version-v2023"]) .uxo-hidden-by-filter {
     opacity: 1 !important;
     max-height: none !important;
     margin: unset !important;

--- a/src/theme/DocSidebar/Desktop/Content.tsx
+++ b/src/theme/DocSidebar/Desktop/Content.tsx
@@ -9,18 +9,21 @@ type Props = WrapperProps<typeof ContentType>;
 
 export default function ContentWrapper(props: Props): React.ReactElement {
     const { pathname } = useLocation();
-    // Show the viewer toggle only for the current (2026+) version.
-    // Old versioned pages (/docs/arender/v4/..., /docs/arender/v2023.x/...) have
-    // no Horizon viewer — the toggle is meaningless there.
-    const isARenderCurrent =
-        pathname.startsWith("/docs/arender") && !/^\/docs\/arender\/v\d/.test(pathname);
+    // Show the viewer toggle on the modern ARender layout: the current version
+    // and every v2026+ snapshot. Only the legacy versioned pages
+    // (/docs/arender/v4/..., /docs/arender/v2023.x/...) have no Horizon viewer,
+    // so we exclude those explicitly. Gating on "no version segment" instead
+    // would drop the toggle from a v2026.x page as soon as a newer version ships.
+    const isARenderModernLayout =
+        pathname.startsWith("/docs/arender") &&
+        !/^\/docs\/arender\/v(4|2023)\b/.test(pathname);
 
     // The parent of this component is a flex column (the sidebar).
     // We render the toggle as a separate flex item that won't shrink,
     // then the Content (menu nav) takes the remaining space and scrolls.
     return (
         <>
-            {isARenderCurrent && <ViewerToggle />}
+            {isARenderModernLayout && <ViewerToggle />}
             <Content {...props} />
         </>
     );

--- a/src/theme/DocSidebar/Mobile/index.tsx
+++ b/src/theme/DocSidebar/Mobile/index.tsx
@@ -12,13 +12,18 @@ import ViewerToggle from "@site/src/components/ViewerToggle/ViewerToggle";
 const DocSidebarMobileSecondaryMenu = ({ sidebar, path }) => {
     const mobileSidebar = useNavbarMobileSidebar();
     const { pathname } = useLocation();
-    // Show the viewer toggle only for current (2026+) — not on old versioned pages.
-    const isARenderCurrent =
-        pathname.startsWith("/docs/arender") && !/^\/docs\/arender\/v\d/.test(pathname);
+    // Show the viewer toggle on the modern ARender layout: the current version
+    // and every v2026+ snapshot. Only the legacy versioned pages (v4, v2023.x)
+    // have no Horizon viewer, so we exclude those explicitly rather than gating
+    // on "no version segment" (which would drop off a v2026.x page as soon as a
+    // newer version ships).
+    const isARenderModernLayout =
+        pathname.startsWith("/docs/arender") &&
+        !/^\/docs\/arender\/v(4|2023)\b/.test(pathname);
 
     return (
         <>
-            {isARenderCurrent && <ViewerToggle />}
+            {isARenderModernLayout && <ViewerToggle />}
             <ul className={clsx(ThemeClassNames.docs.docSidebarMenu, "menu__list")}>
                 <DocSidebarItems
                     items={sidebar}


### PR DESCRIPTION
Promotion `staging` -> `master` to ship the ARender doc layout fix to production (doc.uxopian.com).

## What this promotes

The only content difference between `staging` and `master` is the fix from #166:

```
src/css/arender.css                      | 22 +++++++++++++---------
src/theme/DocSidebar/Desktop/Content.tsx | 15 +++++++++------
src/theme/DocSidebar/Mobile/index.tsx    | 13 +++++++++----
3 files changed, 31 insertions(+), 19 deletions(-)
```

The modern ARender **classic** layout (vertical sidebar + Classic/Horizon toggle, no horizontal secondary nav) was gated on "is the current version". As soon as a newer version shipped, the previous 2026.x snapshot moved to a versioned URL and reverted to the legacy secondary-nav layout. The fix gates on the actually-legacy versions (v4, v2023.x) instead, so every v2026+ snapshot keeps the modern layout.

Verified on staging.

## No other work rides along

The other commits that appear "ahead" on `master` are past `staging` -> `master` merge commits; their content is already on both sides. The net file diff is exactly the 3 files above, nothing else.

## Cross-product isolation

No impact on FAST2 / FlowerDocs / Uxopian AI:
- CSS scoped `[class*="plugin-id-arender"]`, targets `.secondary-nav--arender` (each product has its own variant, untouched).
- Theme swizzles are global but the ViewerToggle is gated on `pathname.startsWith("/docs/arender")`; the `<Content>` passthrough is identical for other products.

## Deploy note

Merging this does **not** auto-deploy to production. `deploy-prod.yml` is manual (`workflow_dispatch`) from `master`. Production ships only when that workflow is run.

Do not merge yet - opened for review/approval.