### PR TITLE
Add release note for v2026.2.0

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -7,7 +7,7 @@ import remarkVariables from "./scripts/remark-variables.mjs";
 // Update these when releasing a new version. They are injected into all
 // markdown files at build time via the remarkVariables script,
 // replacing {{version}} placeholders.
-const arenderVersion = "2026.1.0";
+const arenderVersion = "2026.2.0";
 
 // Suppress the "unmaintained" banner only on the LTS — the highest snapshot
 // major strictly below `current`. We allow at most two maintained majors in

--- a/src/generated/arenderReleases.json
+++ b/src/generated/arenderReleases.json
@@ -1,12 +1,20 @@
 [
   {
+    "version": "v2026.2.0",
+    "title": "ARender v2026.2.0 - Release Notes",
+    "date": "2026-07-31",
+    "description": "Second minor on the 2026 line: a new M-Files provider, underline annotations and comments panel refinements in ARender Horizon, plus Classic annotation fixes, Rendition fixes and security hardening.",
+    "slug": "/release-note/arender/v2026.2.0/release-notes",
+    "hasUpgradeNotes": true,
+    "latest": true
+  },
+  {
     "version": "v2026.1.0",
     "title": "ARender v2026.1.0 - Release Notes",
     "date": "2026-06-26",
     "description": "First minor on the 2026 line: ARender Horizon gains highlight annotations, a comments panel, and a redesigned left panel; plus Classic, Rendition and security fixes.",
     "slug": "/release-note/arender/v2026.1.0/release-notes",
-    "hasUpgradeNotes": true,
-    "latest": true
+    "hasUpgradeNotes": true
   },
   {
     "version": "v2026.0.0",

--- a/src/pages/release-note/arender/v2026.2.0/release-notes.md
+++ b/src/pages/release-note/arender/v2026.2.0/release-notes.md
@@ -1,0 +1,128 @@
+---
+title: "ARender v2026.2.0 - Release Notes"
+draft: false
+date: "2026-07-31"
+weight: -202602
+aliases:
+  - /release/2026.2/
+description: "Second minor on the 2026 line: a new M-Files provider, underline annotations and comments panel refinements in ARender Horizon, plus Classic annotation fixes, Rendition fixes and security hardening."
+_build:
+  list: never
+---
+
+import DocLink from '@site/src/components/DocLink';
+
+<div className="arender-release-notes">
+
+# ARender v2026.2.0 - Release Notes
+
+ARender 2026.2.0 is the second minor release on the 2026 line. It adds a new **M-Files provider** so documents can be viewed and annotated directly from M-Files vaults, continues to expand annotation tooling in **ARender Horizon** (underline annotations and comments panel refinements), and rounds out the release with Classic annotation fixes, Rendition fixes and security hardening.
+
+As in the previous release, the changes below are grouped by viewer: a shared **Security** section, then **ARender Horizon (React)**, **ARender Classic (GWT)**, and finally **Rendition & platform** for everything that applies to both viewers (backend, conversion, integrations).
+
+:::tip Upgrade note
+See the [v2026.2.0 upgrade notes](../upgrade-notes) for step-by-step migration instructions.
+:::
+
+---
+
+## Security
+
+Applies to the whole platform (both viewers).
+
+#### Security fixes and dependency updates
+
+`Changed` - This release includes security hardening across the platform together with updates to third-party dependencies to address known vulnerabilities. For details on the specific issues addressed, please contact [ARender support](https://arondor.atlassian.net/servicedesk/customer/portals).
+
+---
+
+## ARender Horizon (React)
+
+Changes specific to the React viewer (ARender Horizon).
+
+### New features and improvements
+
+#### Underline annotations
+
+`New` - ARender Horizon can now underline selected text, with a color palette to choose the underline color. This complements the highlight-on-selection tool added in 2026.1.0 and brings Horizon closer to annotation parity with Classic.
+
+#### Comments panel refinements
+
+`Changed` - The Horizon comments panel introduced in 2026.1.0 gains interactive comment pins on the document page, kept in sync both ways with the comment list: hovering a pin highlights the matching comment and scrolls it into view, and selecting a comment points back to its pin. Comments are also grouped by status (open and closed) so long discussions stay easy to scan.
+
+---
+
+## ARender Classic (GWT)
+
+Changes specific to the Classic (GWT) viewer.
+
+### Bug fixes
+
+#### Annotation selection indicator
+
+`Fixed` - Selecting a circle or polygon annotation again shows the selection indicator, so it is clear which annotation is currently selected before moving or resizing it.
+
+#### Adding an annotation inside another one
+
+`Fixed` - Creating an annotation on top of (inside) an existing annotation no longer makes the first annotation disappear or prevents the document from being displayed. Both annotations are kept and the document renders normally.
+
+---
+
+## Rendition & platform (both viewers)
+
+Backend, conversion and integration changes that apply regardless of the viewer.
+
+### New features and improvements
+
+#### M-Files provider
+
+`New` - ARender can now view, annotate and retrieve metadata for documents stored in M-Files vaults, through a dedicated M-Files provider available on both ARender Horizon and the Rendition Engine. See the <DocLink version="v2026.2.0" product="arender" to="guides/integration/m-files">M-Files integration guide</DocLink> for setup instructions.
+
+### Bug fixes
+
+#### Annotations no longer fail to load on an empty bounding box
+
+`Fixed` - When an annotation file contained an annotation with an empty bounding box (a valid output of older paste operations), all annotations silently failed to load at document open and the annotation panel appeared empty until a manual refresh. Annotations now load correctly on the first display.
+
+#### Watermark top-left position
+
+`Fixed` - A watermark configured with the `TOP_LEFT` position is now rendered in the top-left corner of the page instead of near the center. See the <DocLink version="v2026.2.0" product="arender" to="guides/features/watermarks#custom-watermark">watermark configuration guide</DocLink> for the supported `watermarkPosition` values.
+
+#### EML to PDF conversion with mismatched image MIME types
+
+`Fixed` - Converting an email (EML) that embeds an image whose binary content does not match its declared MIME type (for example GIF bytes served as `image/png`) no longer fails; the message converts and displays correctly.
+
+#### Logging library conflict in the Document Service Broker image
+
+`Fixed` - The Document Service Broker Docker image no longer bundles conflicting logging libraries, aligning the image with the intended logging stack and removing a source of startup warnings.
+
+---
+
+## Changelog
+
+| Summary | Viewer | Type | Key | Linked Issues |
+|---------|--------|------|-----|---------------|
+| Security hardening | Both | Security | AR-18438 | |
+| Security hardening | Both | Security | AR-18440 | |
+| Dependency security update | Both | Security | AR-18522 | |
+| Dependency security update | Both | Security | AR-18561 | |
+| Add underline annotation with color selection | Horizon | Evolution | AR-18450 | |
+| Group comments by status in the comments panel | Horizon | Evolution | AR-17923 | |
+| Interactive comment pins synchronized with the comment list | Horizon | Evolution | AR-17930 | |
+| M-Files provider | Both | New feature | AR-18346 | |
+| Annotation selection indicator not displayed for circle and polygon annotations | Classic | Regression | AR-18466 | TMAPR-6864 |
+| Adding an annotation inside another one prevents the document from being displayed | Classic | Bug fix | AR-18477 | TMAPR-6886 |
+| All annotations fail to load when one has an empty bounding box | Both | Bug fix | AR-18390 | TMAPR-5817 |
+| Watermark TOP_LEFT position not applied | Both | Bug fix | AR-18300 | TMAPR-6801 |
+| NPE in EML-to-PDF conversion when an embedded image has a mismatched MIME type | Both | Bug fix | AR-18420 | TMAPR-6894 |
+| Document Service Broker image bundles conflicting logging libraries | Both | Bug fix | AR-18560 | TMAPR-6779 |
+
+---
+
+## Download
+
+import ARenderDownloads from '@site/src/components/ARenderDownloads';
+
+<ARenderDownloads version="2026.2.0" filter={["rendition", "web-ui", "connector-filenet", "plugin-filenet", "plugin-alfresco", "plugin-alfresco-adf", "client-api", "rendition-api"]} />
+
+</div>

--- a/src/pages/release-note/arender/v2026.2.0/release-notes.md
+++ b/src/pages/release-note/arender/v2026.2.0/release-notes.md
@@ -16,7 +16,7 @@ import DocLink from '@site/src/components/DocLink';
 
 # ARender v2026.2.0 - Release Notes
 
-ARender 2026.2.0 is the second minor release on the 2026 line. It adds a new **M-Files provider** so documents can be viewed and annotated directly from M-Files vaults, continues to expand annotation tooling in **ARender Horizon** (underline annotations and comments panel refinements), and rounds out the release with Classic annotation fixes, Rendition fixes and security hardening.
+ARender 2026.2.0 is the second minor release on the 2026 line. It adds a new **M-Files provider** so documents can be viewed directly from M-Files vaults, continues to expand annotation tooling in **ARender Horizon** (underline annotations and comments panel refinements), and rounds out the release with Classic annotation fixes, Rendition fixes and security hardening.
 
 As in the previous release, the changes below are grouped by viewer: a shared **Security** section, then **ARender Horizon (React)**, **ARender Classic (GWT)**, and finally **Rendition & platform** for everything that applies to both viewers (backend, conversion, integrations).
 
@@ -76,7 +76,7 @@ Backend, conversion and integration changes that apply regardless of the viewer.
 
 #### M-Files provider
 
-`New` - ARender can now view, annotate and retrieve metadata for documents stored in M-Files vaults, through a dedicated M-Files provider available on both ARender Horizon and the Rendition Engine. See the <DocLink version="v2026.2.0" product="arender" to="guides/integration/m-files">M-Files integration guide</DocLink> for setup instructions.
+`New` - ARender can now view and retrieve metadata for documents stored in M-Files vaults, through a dedicated M-Files provider available on both ARender Horizon and the Rendition Engine. Annotation support is not yet handled by the provider and is planned for a future release. See the <DocLink version="v2026.2.0" product="arender" to="guides/integration/m-files">M-Files integration guide</DocLink> for setup instructions.
 
 ### Bug fixes
 

--- a/src/pages/release-note/arender/v2026.2.0/upgrade-notes.md
+++ b/src/pages/release-note/arender/v2026.2.0/upgrade-notes.md
@@ -1,0 +1,68 @@
+---
+title: "ARender v2026.2.0 – Upgrade Notes"
+draft: false
+date: "2026-07-31"
+weight: -202602
+_build:
+  list: never
+---
+
+import DocLink from '@site/src/components/DocLink';
+
+> **Release note:** See [v2026.2.0](../release-notes).
+
+## ⚙️ Customization and Configuration
+
+### New Properties
+
+**M-Files provider (ARender Horizon).** The new `mfiles-provider` microservice is configured through Spring Boot externalized configuration; every property below can also be set as an environment variable (`ARENDER_SERVER_MFILES_WEB_URL`, …). See the <DocLink version="v2026.2.0" product="arender" to="guides/integration/m-files">M-Files integration guide</DocLink>.
+
+* **`arender.server.mfiles.web-url`** (default: `http://localhost/REST/`) — M-Files Web Service base URL. It **must** end with `/REST/`.
+* **`arender.server.mfiles.authentication.token`** (default: empty) — pre-generated M-Files REST API token. Use this *or* the service-account triplet below, not both.
+* **`arender.server.mfiles.authentication.username`**, **`arender.server.mfiles.authentication.password`**, **`arender.server.mfiles.authentication.vault-guid`** (default: empty) — service-account mode; the provider fetches a token once at the first request.
+
+**Rendition Engine registry.** Routing to the new provider is declared in the Document Service Broker `application.yaml`:
+
+* **`registry.providers.mfiles.base-url`** (default: `http://localhost:8789`) — where the broker reaches the `mfiles-provider` container.
+* **`registry.providers.mfiles.whitelisted-params`** (default: `objectType`, `docId`, `versionId`, `fileId`, `title`) — query parameters forwarded to the provider.
+
+:::info
+Requests are routed to the M-Files provider by the `X-Provider-ID: mfiles` header injected by your BFF or reverse proxy. If M-Files is your only repository, set `registry.default-provider=mfiles` instead.
+:::
+
+
+### Changed and Deprecated Properties
+
+* **`watermarkPosition`** (custom watermark, values `CENTER` and `TOP_LEFT`) — the `TOP_LEFT` value is now actually honored. Until this release a watermark declared as `TOP_LEFT` was drawn near the center of the page; it is now drawn in the top-left corner. Watermark rotation and the surrounding frame are also applied consistently for both positions. See the <DocLink version="v2026.2.0" product="arender" to="guides/features/watermarks#custom-watermark">watermark configuration guide</DocLink>.
+
+:::warning[Breaking change from v2026.1.0]
+If a custom watermark was configured with `watermarkPosition = TOP_LEFT` and its style (offsets, font size) was tuned against the old, incorrectly centered rendering, the watermark will move after the upgrade.
+
+**Action required:** review custom watermark definitions using `TOP_LEFT` and re-check the rendered output, or set `watermarkPosition` to `CENTER` to keep the previous placement.
+:::
+
+No properties were renamed or deprecated in this release.
+
+### Deleted Properties
+
+No properties were removed in this release.
+
+## 📦 Product
+
+### Technical Changes and Security
+
+* **DOMPurify `3.4.0` → `3.4.12`**
+* **Log4j binaries removed from the Docker images.** `log4j-core-*.jar` and `log4j-1.2-api-*.jar` are now filtered out of `arender-document-converter`, `arender-document-renderer`, `arender-document-renderer-pdfowl`, `arender-document-text-handler`, `arender-document-service-broker` and `arender-ui-springboot`. They were pulled in transitively, conflicted with the intended logging stack and produced startup warnings.<br/>
+<u>**Impact:**</u> ARender itself is unaffected — it logs through SLF4J/Logback. If you mount a custom extension into these images that requires Log4j 1.x or 2.x classes at runtime, ship the library with your extension.
+* **New Docker image `arender-mfiles-provider`** for the M-Files provider, exposing port `8789`.
+
+### Behavior Changes
+
+* **Redaction now covers images** Redaction annotations previously removed only text and drew an opaque box over the page; image pixels under the box were still present in the burnt PDF. Image content covered by a redaction is now removed from the image data itself.<br/>
+<u>**Impact:**</u> when an image cannot be rewritten surgically, ARender fails closed and flattens the whole page to a raster. Text on such pages is no longer selectable or searchable in the produced PDF, and the file may be larger. This only affects pages that carry a redaction annotation.
+
+* **Invalid annotations no longer block the whole annotation set** An annotation with an empty bounding box — a valid output of older paste operations — used to make every annotation of the document fail to load. Such annotations are now skipped at parsing, so the remaining ones load on first display; they are also skipped when burning annotations into a downloaded PDF.<br/>
+<u>**Impact:**</u> the skipped annotations are no longer rendered at all, where previously the document either showed none of them or showed them at an undefined position.
+
+* **Unsaved-annotation prompt on every document change** The *"Do you want to save annotation(s)?"* prompt was only raised when the document was changed by id (for example a thumbnail click). It is now raised for relative and absolute document changes as well, which covers the document navigation panel (first / previous / next / last) and document changes triggered through the JavaScript API.<br/>
+


### PR DESCRIPTION
## ARender v2026.2.0 - Release Notes

Adds the public release note for ARender v2026.2.0 (second minor on the 2026 line), in the v2026.1.0 style (viewer-split layout).

### Files
- `src/pages/release-note/arender/v2026.2.0/release-notes.md` (new)
- `src/generated/arenderReleases.json` (v2026.2.0 at top, `latest`; 2026.1.0 demoted)
- `docusaurus.config.ts` (`arenderVersion` -> 2026.2.0)

### Highlights
- New **M-Files provider** (view, annotate and retrieve metadata from M-Files vaults)
- **Horizon**: underline annotations, comments panel refinements
- **Classic** annotation fixes; **Rendition** fixes (watermark top-left, EML conversion, empty-rect annotation load); Docker logging packaging fix
- Security hardening and dependency updates

### Notes for the reviewer
- **Date is a placeholder (2026-07-31)** in the frontmatter and `arenderReleases.json` - swap for the real GA date before merge.
- The upgrade-note admonition links `../upgrade-notes`; `v2026.2.0/upgrade-notes.md` is owned by the tech lead and 404s until it is added.
- Two DocLinks (M-Files, watermark) verified to resolve on the branch.
