### PR TITLE
AR-18575: documentation for loading a document - new contract

### DIFF
--- a/docs/arender/concepts/documents-and-ids.horizon.md
+++ b/docs/arender/concepts/documents-and-ids.horizon.md
@@ -22,7 +22,11 @@ The internal string representation is opaque to most consumers. By default ARend
 b64_dXJsPWh0dHA6Ly9leGFtcGxlLmNvbS9zYW1wbGUucGRm
 ```
 
-You will see these IDs in viewer URLs and in broker logs. Different [ID generators](../guides/features/document-id-generators.md) produce different formats (encrypted, UUID-based), but from a consumer's perspective the ID is always an opaque string.
+You will see these IDs in broker logs, and in the `uuid` parameter the viewer accepts for an already-resolved document. Different [ID generators](../guides/features/document-id-generators.md) produce different formats (encrypted, UUID-based), but from a consumer's perspective the ID is always an opaque string.
+
+:::note
+`uuid` is the only parameter name the viewer interprets itself: passed alone, its value is treated as a `DocumentId` and no repository call is made. A repository must therefore never use `uuid` as one of its own parameter names. See [Opening documents](../guides/features/opening-documents.md#opening-a-document-by-pre-generated-id).
+:::
 
 :::info
 When opening documents by URL, the rendition service only authorizes whitelisted domains. By default, no domain is authorized. See [Opening documents](../guides/features/opening-documents.md) for configuration.
@@ -52,7 +56,7 @@ Regardless of how the `DocumentAccessor` is created, the rest of the rendition p
 
 ## Related pages
 
-- [Opening documents](../guides/features/opening-documents.md): URL parameters and multi-document opening
+- [Opening documents](../guides/features/opening-documents.md): the `openDocument` parameter contract and multi-document opening
 - [Document ID generators](../guides/features/document-id-generators.md): configuring Base64, encrypted, and UUID generators
 - [Providers](../guides/integration/providers.md): how providers load documents via REST
 - [Rendition caching](./caching.md): how `DocumentId` values are used as cache keys

--- a/docs/arender/guides/features/opening-documents.horizon.md
+++ b/docs/arender/guides/features/opening-documents.horizon.md
@@ -38,7 +38,7 @@ window.ARender.openDocument(`url=${encodeURIComponent(docUrl)}`);
 The rendition service has a safeguard that only authorizes whitelisted domain/host URLs. By default, no domain is authorized. See the broker environment variable `DSB_AUTHORIZED_URLS`.
 :::
 
-Skipping `encodeURIComponent` happens to work as long as the URL has no query string of its own. As soon as it has one — a pre-signed URL, for instance — its `&` and `=` are read as parameter separators and the request is silently corrupted. Encode every value: see [Web Component → Encoding is the caller's responsibility](../../reference/web-component.md#encoding-is-the-callers-responsibility).
+Skipping `encodeURIComponent` happens to work as long as the URL has no query string of its own. As soon as it has one — a pre-signed URL, for instance — its `&` and `=` are read as parameter separators and the request is silently corrupted. Encode every value: see [Web Component → Encoding URL](../../reference/web-component.md#encoding-url).
 
 ## Opening a document from a repository
 

--- a/docs/arender/guides/features/opening-documents.horizon.md
+++ b/docs/arender/guides/features/opening-documents.horizon.md
@@ -11,66 +11,107 @@ content_hash: 0756282479e4788cf77adb689d81ba772ec51b9b7b40f44b4538d264acb10b32
 
 # Opening documents
 
-ARender accepts documents through URL parameters on the main viewer page. This page covers all the ways to open documents in the viewer.
+A document is requested by passing a **query string of the parameters that identify it**. There is one contract, with two entry points:
 
-For a quick hands-on introduction, see the quickstart guide for your viewer.
+| Entry point | When to use it |
+|-------------|----------------|
+| `document` attribute on `<arender-element>` | The document displayed when the viewer mounts |
+| `window.ARender.openDocument(params)` | Any time afterwards |
+
+Both take the same string, and the viewer forwards it verbatim to the backend, which resolves it into an ARender document ID.
+
+For the full rules — encoding, repeated parameters, the reserved `uuid` name — see [Web Component → Parameter contract](../../reference/web-component.md#parameter-contract).
 
 ## Opening a document by URL
 
-Pass a `url` parameter pointing to an HTTP-accessible document:
+Pass a `url` parameter pointing to an HTTP-accessible document, with the URL itself encoded:
 
+```javascript
+window.ARender.openDocument(`url=${encodeURIComponent(docUrl)}`);
 ```
-https://your-arender-host/?url=https://example.com/contract.pdf
+
+```jsx
+<arender-element rendition="/" document={`url=${encodeURIComponent(docUrl)}`} />
 ```
 
 :::info
 The rendition service has a safeguard that only authorizes whitelisted domain/host URLs. By default, no domain is authorized. See the broker environment variable `DSB_AUTHORIZED_URLS`.
 :::
 
+Skipping `encodeURIComponent` happens to work as long as the URL has no query string of its own. As soon as it has one — a pre-signed URL, for instance — its `&` and `=` are read as parameter separators and the request is silently corrupted. Encode every value: see [Web Component → Encoding is the caller's responsibility](../../reference/web-component.md#encoding-is-the-callers-responsibility).
+
+## Opening a document from a repository
+
+Pass the parameters your provider expects. The viewer forwards them untouched, so no viewer-side configuration is needed:
+
+```javascript
+// Alfresco
+window.ARender.openDocument('nodeRef=4aa144a5-a0b1-4c2d-8e3f-1234567890ab&user=admin&alf_ticket=TICKET_xxx&versionLabel=1.0');
+
+// FileNet
+window.ARender.openDocument('objectStoreName=OS1&id=93DFA526-1B2C-4D3E-8F90-ABCDEF123456');
+
+// M-Files
+window.ARender.openDocument('objectType=0&docId=521&versionId=latest');
+```
+
+See [Providers](../integration/providers.md) for the parameters each repository expects and for the `X-Provider-ID` routing performed by the gateway.
+
 ## Opening a document by pre-generated ID
 
 Pass a `uuid` parameter containing a previously generated `DocumentId`:
 
-```
-https://your-arender-host/?uuid=b64_dXJsPWh0dHA6Ly9leGFtcGxlLmNvbS9zYW1wbGUucGRm
+```javascript
+window.ARender.openDocument('uuid=b64_dXJsPWh0dHA6Ly9leGFtcGxlLmNvbS9zYW1wbGUucGRm');
 ```
 
-This is the typical pattern when an external system (a connector, an ECM plugin, or a backend call) has already loaded the document and registered it with the Document Service Broker. The viewer looks up the existing `DocumentAccessor` from the cache rather than fetching the document again.
+This is the typical pattern when an external system (a provider, an ECM plugin, or a backend call) has already loaded the document and registered it with the Document Service Broker. The viewer looks up the existing `DocumentAccessor` from the cache rather than fetching the document again — **no repository call is made**.
+
+`uuid` is a reserved parameter name for this reason: a repository must never use it for its own purposes.
 
 ## Multi-document opening
 
-There are two modes for displaying multiple documents simultaneously.
+There are three ways to display several documents simultaneously.
+
+### Several URLs
+
+Repeat the `url` parameter. The documents are displayed in the given order, as a single container:
+
+```javascript
+window.ARender.openDocument(`url=${encodeURIComponent(urlA)}&url=${encodeURIComponent(urlB)}`);
+```
+
+### Several files of the same repository object
+
+Repositories that identify files with parallel lists pass them as repeated parameters. Per-key order is preserved end to end, so the lists stay paired by index:
+
+```javascript
+window.ARender.openDocument('objectType=0&docId=534&fileId=576&fileId=977&title=a.pdf&title=b.pdf');
+```
+
+See [M-Files → Opening a document](../integration/m-files.md#opening-a-document) for a worked example.
 
 ### Pre-built DocumentContainer
 
-A connector or backend code can programmatically create a `DocumentContainer`, populate its children with `DocumentReference` objects, and register it with the document service. The viewer then receives a single `uuid` pointing to the container.
+A provider or backend code can programmatically create a `DocumentContainer`, populate its children with `DocumentReference` objects, and register it with the document service. The viewer then receives a single `uuid` pointing to the container.
 
-In both cases, child documents have [hierarchical DocumentId values](../../concepts/documents-and-ids.md#hierarchical-ids) derived from the container's root ID.
+In every case, child documents have [hierarchical DocumentId values](../../concepts/documents-and-ids.md#hierarchical-ids) derived from the container's root ID.
 
-### Multiple URL parameters
+## Changing the document at runtime
 
-Not supported yet.
-
-
-## Opening a document at runtime
-
-To open or change a document after the page has loaded, use the JavaScript API instead of URL parameters:
+Call `openDocument()` again — the most recent request wins:
 
 ```javascript
-window.ARender.openDocumentByUrl('https://example.com/contract.pdf');
+window.ARender.openDocument(`url=${encodeURIComponent(otherContractUrl)}`);
 ```
 
 This is the typical pattern when the document to display depends on a user action (clicking a row in a table, selecting a file, etc.). Calls made before the viewer finishes mounting are queued automatically — no need to wait for any event.
 
-You can also open a document by its pre-generated ARender ID:
+The `document` attribute, by contrast, is read only when the component mounts: changing it afterwards has no effect.
 
-```javascript
-window.ARender.openDocument('b64_dXJsPWh0dHA6Ly9leGFtcGxlLmNvbS9zYW1wbGUucGRm');
-```
-
-See [Web Component → JavaScript API](../../reference/web-component.md#javascript-api) for the full API reference.
 
 ## Related pages
 
+- [Web Component](../../reference/web-component.md): attributes, JavaScript API, and the full parameter contract
 - [Documents and document IDs](../../concepts/documents-and-ids.md): the DocumentId / DocumentAccessor mental model
 - [Document ID generators](./document-id-generators.md): how IDs are generated and configured

--- a/docs/arender/guides/integration/alfresco.horizon.md
+++ b/docs/arender/guides/integration/alfresco.horizon.md
@@ -16,7 +16,7 @@ The `alfresco-provider` runs as a Docker container alongside the ARender renditi
 
 ```mermaid
 %%{init: {'theme': 'neutral'}}%%
-%% Modern viewer Alfresco integration
+%% ARender Horizon Alfresco integration
 flowchart LR
   classDef client fill:#4A90D9,color:#fff
   classDef arender fill:#27AE60,color:#fff
@@ -36,7 +36,7 @@ flowchart LR
   Provider -- "CMIS 1.1 AtomPub" --> Alfresco
 ```
 
-*Figure: Request flow from the Modern viewer to Alfresco through the provider.*
+*Figure: Request flow from ARender Horizon to Alfresco through the provider.*
 
 ## 2. Prerequisites
 
@@ -106,6 +106,14 @@ The following query parameters are used by the provider. The broker forwards all
 | `docs` | Yes (multi-document) | Comma-separated list of `nodeRef;versionLabel` pairs |
 | `folder` | No | When set with `nodeRef`, opens the nodeRef as a folder and returns its children |
 
+The host application passes these parameters to the viewer as a single query string, which reaches the provider untouched:
+
+```javascript
+window.ARender.openDocument('nodeRef=4aa144a5-a0b1-4c2d-8e3f-1234567890ab&user=admin&alf_ticket=TICKET_xxx&versionLabel=1.0');
+```
+
+See [Web Component → Parameter contract](../../reference/web-component.md#parameter-contract) for the encoding rules, and note that `uuid` is reserved by the viewer — never use it as an Alfresco parameter name.
+
 :::note
 `whitelistedParams` controls which parameters form the internal `DocumentId` used for caching. Parameters outside the list are still forwarded to the provider. Do not add `alf_ticket` to `whitelistedParams`: it is a short-lived per-user token, and including it in the cache key causes every request with a new ticket to miss the cache, forcing unnecessary re-rendition of the same document.
 :::
@@ -142,14 +150,20 @@ curl http://alfresco-provider:8788/documents?nodeRef=<nodeRef>&alf_ticket=<ticke
 
 Expected response: document binary stream with `Content-Disposition` and `Content-Type` headers.
 
-2. Open the ARender Modern viewer and load a document from Alfresco. Check that the document renders without error.
+2. Open ARender Horizon and load a document from Alfresco:
+
+```javascript
+window.ARender.openDocument('nodeRef=<nodeRef>&user=<user>&alf_ticket=<ticket>');
+```
+
+Check that the document renders without error.
 
 ## 6. Sample use case
 
-A legal department uses Alfresco to manage contract documents. The Modern viewer is embedded in an Angular application using `angular-arender-ui`. When a user opens a contract from the Alfresco document library:
+A legal department uses Alfresco to manage contract documents. ARender Horizon is embedded in an Angular application through the `<arender-element>` Web Component. When a user opens a contract from the Alfresco document library:
 
 1. The Angular application retrieves the user's Alfresco ticket from the session.
-2. The application builds the viewer URL with `nodeRef`, `alf_ticket`, and `user` parameters.
+2. The application calls `window.ARender.openDocument('nodeRef=…&user=admin&alf_ticket=…')`.
 3. The `<arender-element>` component sends the request to the BFF.
 4. The BFF injects `X-Provider-ID: alfresco` and forwards to the broker.
 5. The broker calls `alfresco-provider:8788/documents?nodeRef=...&alf_ticket=...&user=...`.
@@ -159,6 +173,7 @@ A legal department uses Alfresco to manage contract documents. The Modern viewer
 
 | Error | Cause | Solution |
 |---|---|---|
-| `Cannot view document, missing info in query parameters` | `nodeRef`, `alf_ticket`, or `user` is absent from the request | Verify that the BFF forwards all required parameters in the request. The broker forwards all incoming parameters to the provider; the issue is in the BFF or the client not sending the required parameters |
+| `Cannot view document, missing info in query parameters` | `nodeRef`, `alf_ticket`, or `user` is absent from the request | Check the query string passed to `openDocument()` first, then that the BFF forwards it unchanged. The broker forwards all incoming parameters to the provider, so a missing parameter comes from the client or the BFF |
+| Opaque `500` with a null `alf_ticket` in the provider logs | A parameter the provider cannot interpret reached it — typically a value whose separators were not encoded, so `alf_ticket` was parsed as part of the previous value | URL-encode every value before concatenating it into the query string. See [Web Component → Parameter contract](../../reference/web-component.md#parameter-contract) |
 | `Connection refused` on CMIS call | The `arender.server.alfresco.atom.pub.url` is unreachable from the provider container | Check network connectivity: `curl <atom-pub-url>` from inside the provider container |
 | `IllegalStateException: NOT IMPLEMENTED` | The request mode (DOCUMENT, FOLDER, MULTIDOCUMENT) could not be determined | Ensure `nodeRef` is present for single document mode, or `docs` for multi-document mode |

--- a/docs/arender/guides/integration/filenet.horizon.md
+++ b/docs/arender/guides/integration/filenet.horizon.md
@@ -16,7 +16,7 @@ The `filenet-provider` runs as a Docker container alongside the ARender renditio
 
 ```mermaid
 %%{init: {'theme': 'neutral'}}%%
-%% Modern viewer FileNet integration
+%% ARender Horizon FileNet integration
 flowchart LR
   classDef client fill:#4A90D9,color:#fff
   classDef arender fill:#27AE60,color:#fff
@@ -38,7 +38,7 @@ flowchart LR
   CE --> Store
 ```
 
-*Figure: Request flow from the Modern viewer to FileNet through the provider.*
+*Figure: Request flow from ARender Horizon to FileNet through the provider.*
 
 ## 2. Prerequisites
 
@@ -162,6 +162,14 @@ The broker forwards the following query parameters to the provider. They must be
 | `objectId` | No | Additional object identifiers (list) |
 | `contentElement` | No | Index of the content element to open when a document has multiple content elements |
 
+The host application passes these parameters to the viewer as a single query string, which reaches the provider untouched:
+
+```javascript
+window.ARender.openDocument('objectStoreName=OS1&id=93DFA526-1B2C-4D3E-8F90-ABCDEF123456');
+```
+
+Parameters are grouped by key and each key keeps its own order, so lists (`ids`, `vsIds`, `objectId`) stay paired by index end to end. See [Web Component → Parameter contract](../../reference/web-component.md#parameter-contract) for the encoding rules, and note that `uuid` is reserved by the viewer — never use it as a FileNet parameter name.
+
 ### Annotation access
 
 The provider exposes annotation CRUD endpoints:
@@ -188,13 +196,19 @@ Expected: a WSDL or service description response from the CE MTOM endpoint.
 
 2. Check provider logs on startup. A successful connection produces log output indicating the CE connection was established.
 
-3. Load a document through the Modern viewer. Confirm the document renders and that no connection errors appear in the provider logs.
+3. Load a document through ARender Horizon:
+
+```javascript
+window.ARender.openDocument('objectStoreName=<objectStoreName>&id=<documentGuid>');
+```
+
+Confirm the document renders and that no connection errors appear in the provider logs.
 
 ## 6. Sample use case
 
-A financial institution uses IBM FileNet to store client contracts. The Modern viewer is embedded in a React application using `react-arender-ui`. When a case worker opens a contract:
+A financial institution uses IBM FileNet to store client contracts. ARender Horizon is embedded in a React application through the `<arender-element>` Web Component. When a case worker opens a contract:
 
-1. The React application authenticates the user via OAuth2 and obtains a JWT.
+1. The React application authenticates the user via OAuth2, obtains a JWT, and calls `window.ARender.openDocument('objectStoreName=OS1&id=…')`.
 2. The `X-Provider-ID: filenet` header is injected by the BFF along with the JWT as a Bearer token.
 3. The broker routes the request to `filenet-provider:8787`.
 4. The provider validates the JWT (OAuth2 resource server), extracts the principal and token, and authenticates to FileNet using the `FileNetP8WSI` JAAS stanza.
@@ -208,5 +222,5 @@ A financial institution uses IBM FileNet to store client contracts. The Modern v
 | `Connection refused` on CE URL | The CE WSI/MTOM endpoint is unreachable from the provider container | Verify network connectivity: `curl <ce-url>` from inside the provider container |
 | Authentication failure with `loginPasswordObjectStoreProvider` | Incorrect credentials or the service account lacks access to the object store | Verify credentials and that the account has the required FileNet roles |
 | JWT validation failure with `oauth2ObjectStoreProvider` | The `spring.security.oauth2.resourceserver.jwt.issuer-uri` does not match the token's issuer | Confirm the issuer URI matches the token's `iss` claim exactly |
-| `IllegalStateException` on document request | Missing `objectStoreName` or `objectStoreId` in request | Ensure the BFF passes the required parameters and they are whitelisted in the broker |
+| `IllegalStateException` on document request | Missing `objectStoreName` or `objectStoreId` in request | Check the query string passed to `openDocument()`, ensure the BFF forwards it unchanged, and that the parameters are whitelisted in the broker |
 | Provider starts but documents return 404 | The `objectType` parameter does not match the FileNet object | Confirm `objectType` is set correctly (`DOCUMENT`, `FOLDER`, etc.) |

--- a/docs/arender/guides/integration/m-files.horizon.md
+++ b/docs/arender/guides/integration/m-files.horizon.md
@@ -16,7 +16,7 @@ The `mfiles-provider` runs as a Docker container alongside the ARender rendition
 
 ```mermaid
 %%{init: {'theme': 'neutral'}}%%
-%% Modern viewer M-Files integration
+%% ARender Horizon M-Files integration
 flowchart LR
   classDef client fill:#4A90D9,color:#fff
   classDef arender fill:#27AE60,color:#fff
@@ -36,7 +36,7 @@ flowchart LR
   Provider -- "HTTP REST (X-Authentication)" --> MFiles
 ```
 
-*Figure: Request flow from the Modern viewer to M-Files through the provider.*
+*Figure: Request flow from ARender Horizon to M-Files through the provider.*
 
 ## 2. Prerequisites
 
@@ -163,13 +163,21 @@ Pass multiple values as **repeated parameters** (`fileId=456&fileId=789`), not a
 
 ### Opening a document
 
-Every open mode goes through `GET /documents`:
+Every open mode goes through `GET /documents`, with the same query string the host application passes to the viewer:
 
 | Mode | Query parameters | Result |
 |---|---|---|
 | Whole object | `objectType=0&docId=521` | The object's file(s): a single-file object is streamed as-is; a multi-file object is returned as a multi-document |
 | One explicit file | `objectType=0&docId=534&fileId=576&title=v2.pdf` | The selected file, named after `title` |
 | Several explicit files | `objectType=0&docId=534&fileId=576&fileId=977&title=v2.pdf&title=mire.pdf` | A multi-document of the selected files, in the given order |
+
+From the host application, that last mode reads:
+
+```javascript
+window.ARender.openDocument('objectType=0&docId=534&fileId=576&fileId=977&title=v2.pdf&title=mire.pdf');
+```
+
+The viewer forwards the string verbatim — it never reorders or re-encodes parameters — so the pairing below survives all the way to the provider. See [Web Component → Parameter contract](../../reference/web-component.md#parameter-contract) for the encoding rules, and note that `uuid` is reserved by the viewer: never use it as an M-Files parameter name.
 
 - `fileId` and `title` are **parallel lists paired by index**, each passed as repeated parameters (see the warning above).
 - `title` is optional but recommended: it sets each file's name and extension so the renderer detects the format reliably. Without it, the format is guessed from the content.
@@ -220,13 +228,19 @@ curl -X POST "http://service-broker:8761/registry/documents?objectType=0&docId=5
 
 Expected: a JSON `DocumentId` (e.g. `{"id":"b64_..."}`).
 
-3. Open the ARender Modern viewer and load a document from M-Files. Check that the document renders without error.
+3. Open ARender Horizon and load a document from M-Files:
+
+```javascript
+window.ARender.openDocument('objectType=0&docId=<docId>&versionId=latest');
+```
+
+Check that the document renders without error.
 
 ## 6. Sample use case
 
-A company stores its documents in an M-Files vault. The Modern viewer is embedded in a web application. When a user opens an M-Files object:
+A company stores its documents in an M-Files vault. ARender Horizon is embedded in a web application through the `<arender-element>` Web Component. When a user opens an M-Files object:
 
-1. The application builds the viewer URL with the `objectType`, `docId`, and `versionId` parameters.
+1. The application calls `window.ARender.openDocument('objectType=0&docId=521&versionId=latest')`.
 2. The `<arender-element>` component sends the request to the BFF.
 3. The BFF injects `X-Provider-ID: mfiles` and forwards to the broker.
 4. The broker calls `mfiles-provider:8789/documents?objectType=0&docId=521&versionId=latest`.

--- a/docs/arender/guides/integration/providers.md
+++ b/docs/arender/guides/integration/providers.md
@@ -34,9 +34,9 @@ sequenceDiagram
     participant Provider as Provider microservice
     participant Repo as Document Repository
 
-    React->>GW: POST /registry/documents
+    React->>GW: POST /registry/documents?params (verbatim)
     GW->>GW: Inject X-Provider-ID header
-    GW->>Broker: POST /registry/documents<br/>X-Provider-ID: alfresco
+    GW->>Broker: POST /registry/documents?params<br/>X-Provider-ID: alfresco
     Broker->>Provider: GET /documents?nodeRef=...
     Provider->>Repo: Fetch document binary
     Repo-->>Provider: Binary content
@@ -49,12 +49,17 @@ sequenceDiagram
     Note over Broker: Render pages using<br/>cached document
 ```
 
-1. The React UI sends a `POST /registry/documents` request to the gateway/BFF.
+1. The React UI sends a `POST /registry/documents` request to the gateway/BFF, carrying the query string it was given through [`openDocument(params)`](../../reference/web-component.md#parameter-contract) or the `document` attribute. The viewer forwards that string verbatim: values are never decoded, re-encoded or reordered.
 2. The gateway injects the `X-Provider-ID` header (e.g., `alfresco`, `filenet`) and forwards the request to the broker.
 3. The broker looks up the provider's URL in its registry and forwards the request with the whitelisted query parameters.
 4. The provider fetches the document from the repository and returns the binary content (or a JSON folder structure for composite documents).
 5. The broker caches the document, generates a `DocumentId`, and returns it through the gateway to the React UI.
 6. Subsequent page rendering requests follow the same path through the gateway.
+
+
+:::warning `uuid` is a reserved parameter name
+A lone `uuid` parameter tells the viewer the document is already resolved — its value is an ARender `DocumentId`, used as-is, and **no provider call is made**. No provider knows that parameter name, so a repository must never use `uuid` for its own purposes: forwarding it produces an opaque backend error instead of a document.
+:::
 
 ## Available providers
 

--- a/docs/arender/guides/upgrade/migration-from-gwt.md
+++ b/docs/arender/guides/upgrade/migration-from-gwt.md
@@ -19,6 +19,7 @@ This page maps GWT viewer concepts to their React UI equivalents. Use it as a re
 |------------|----------|-------|
 | Standalone application (`arender-ui-springboot`) | npm package embedded as Web Component | See [Getting started](../../quickstart/getting-started.md) |
 | `<iframe>` embed | `<arender-element>` Web Component | See [Web Component](../../reference/web-component.md) |
+| Document parameters in the iframe URL (`?nodeRef=…`, `?url=…`, `?uuid=…`) | `document` attribute or `openDocument(params)`, taking the same query string | The address bar no longer opens documents. See [Opening documents](../features/opening-documents.md) |
 | `window.arender.jsapi` | `window.ARender` / `element.ARender` | See [Web Component — JavaScript API](../../reference/web-component.md#javascript-api) |
 | `.properties` files | HTML attributes, JavaScript API | See [Configuration](../../installation/configuration.md) |
 | Connector JARs (bundled in viewer) | Provider microservices (separate containers) | See [Providers](../integration/providers.md) |
@@ -47,7 +48,8 @@ You do not need to change your backend deployment when switching viewers.
 
 - **Delivery model:** The GWT viewer is a standalone Spring Boot application; the React UI is an npm package embedded in your application
 - **Embedding:** `<iframe>` pointing to the viewer URL becomes `<arender-element>` in the host page DOM
-- **JavaScript API:** `arender.jsapi.*` namespace becomes `window.ARender.*` (2 methods: `openDocument`, `openDocumentByUrl`)
+- **JavaScript API:** `arender.jsapi.*` namespace becomes `window.ARender.*`, with a single method to open a document: `openDocument(params)`
+- **Document requests:** the parameters you used to put in the iframe URL query string are passed to `openDocument()` (or the `document` attribute) as the same query string, forwarded verbatim to the backend. The address bar of the host page never opens a document
 - **Configuration:** `.properties` files become HTML attributes and JavaScript calls
 - **Connector model:** Java JARs in the viewer classpath become standalone provider microservices
 - **Network:** The host application must proxy or allow cross-origin requests to the broker (see [CORS and reverse proxy](../../installation/configuration.md#cors-and-reverse-proxy))
@@ -57,7 +59,7 @@ You do not need to change your backend deployment when switching viewers.
 1. Install the `arender-ui` npm package (or a framework wrapper) in your host application
 2. Replace `<iframe>` embeds with `<arender-element>` Web Component
 3. Set up a reverse proxy or CORS configuration for the broker API routes
-4. Update JavaScript integrations to use the `window.ARender` / `element.ARender` API
+4. Update JavaScript integrations to use the `window.ARender` / `element.ARender` API, moving the document parameters out of the iframe URL and into `openDocument(params)` — URL-encoding every value
 5. If using repository connectors (Alfresco, FileNet), deploy the corresponding provider microservice and register it in the broker
 6. Test core workflows: viewing, annotation, search, redaction
 7. Verify features you depend on are available in the React UI (see [key capabilities](../../overview/horizon.md#key-capabilities))

--- a/docs/arender/installation/docker-compose.horizon.md
+++ b/docs/arender/installation/docker-compose.horizon.md
@@ -168,7 +168,7 @@ If OAuth2 is enabled on the rendition backend, use a BFF instead of a plain reve
 
 ## Step 3 — Configure authorized document sources
 
-When loading documents by URL (via `openDocumentByUrl`), the broker must authorize the source domain. Add `DSB_AUTHORIZED_URLS` to the broker service in your `docker-compose.yml`:
+When loading documents by URL (via `openDocument()` or the `document` attribute with a `url` parameter), the broker must authorize the source domain. Add `DSB_AUTHORIZED_URLS` to the broker service in your `docker-compose.yml`:
 
 ```yaml
 service-broker:

--- a/docs/arender/quickstart/getting-started.md
+++ b/docs/arender/quickstart/getting-started.md
@@ -123,11 +123,16 @@ The table below lists the attributes you can set directly on the element:
 | Attribute | Required | Description |
 |-----------|----------|-------------|
 | `rendition` | Yes | URL of the ARender rendition backend. Use `/` when proxied with Vite, or `http://localhost:4200/` with Angular (see Step 3). |
-| `url` | No | URL of the document to open on startup. |
-| `uuid` | No | ID of the document to open on startup (alternative to `url`). |
+| `document` | No | Query string of the parameters identifying the document to open on startup, e.g. `url=https://example.com/doc.pdf`. |
 
-Set `url` or `uuid` directly as HTML attributes to open a document on startup — no JavaScript needed.
+Set `document` directly as an HTML attribute to open a document on startup — no JavaScript needed. The attribute is read once, when the component mounts.
 To load a different document at runtime, use the [JavaScript API](#step-5--load-a-document-dynamically).
+
+:::note
+The `document` attribute takes the same query string as the JavaScript API: `url=…` for a document reachable over HTTP, `uuid=…` for an already-resolved ARender document ID, or the parameters your repository expects.
+
+Every value must be URL-encoded, so bind the attribute instead of hardcoding it — ``document={`url=${encodeURIComponent(docUrl)}`}`` — and let `encodeURIComponent` do the escaping. See [Web Component → Parameter contract](../reference/web-component.md#parameter-contract).
+:::
 
 
 <Tabs>
@@ -145,8 +150,7 @@ declare module 'react' {
     interface IntrinsicElements {
       'arender-element': React.HTMLAttributes<HTMLElement> & {
         rendition?: string
-        url?: string
-        uuid?: string
+        document?: string
       }
     }
   }
@@ -155,6 +159,8 @@ declare global {
   interface Window { ARender: ARenderHTMLElement }
 }
 
+const DOC_URL = 'https://www.uxopian.com/hubfs/PDFReference15_v5.pdf'
+
 function App() {
   useEffect(() => { import('arender-ui') }, [])
 
@@ -162,7 +168,7 @@ function App() {
     <div style={{ width: '100%', height: '100vh' }}>
       <arender-element
         rendition="/"
-        url="https://www.uxopian.com/hubfs/PDFReference15_v5.pdf"
+        document={`url=${encodeURIComponent(DOC_URL)}`}
       />
     </div>
   )
@@ -180,6 +186,9 @@ Copy the following into your `src/App.vue` file, replacing its entire contents:
 <script setup lang="ts">
 import { onMounted } from 'vue'
 
+const DOC_URL = 'https://www.uxopian.com/hubfs/PDFReference15_v5.pdf'
+const documentParams = `url=${encodeURIComponent(DOC_URL)}`
+
 onMounted(() => { import('arender-ui') })
 </script>
 
@@ -187,7 +196,7 @@ onMounted(() => { import('arender-ui') })
   <div style="width: 100%; height: 100vh">
     <arender-element
       rendition="/"
-      url="https://www.uxopian.com/hubfs/PDFReference15_v5.pdf"
+      :document="documentParams"
     />
   </div>
 </template>
@@ -210,13 +219,16 @@ Copy the following into your `src/App.svelte` file, replacing its entire content
 <script lang="ts">
   import { onMount } from 'svelte'
 
+  const DOC_URL = 'https://www.uxopian.com/hubfs/PDFReference15_v5.pdf'
+  const documentParams = `url=${encodeURIComponent(DOC_URL)}`
+
   onMount(() => { import('arender-ui') })
 </script>
 
 <div style="width: 100%; height: 100vh">
   <arender-element
     rendition="/"
-    url="https://www.uxopian.com/hubfs/PDFReference15_v5.pdf"
+    document={documentParams}
   ></arender-element>
 </div>
 ```
@@ -229,6 +241,8 @@ Copy the following into your `src/app/app.component.ts` file, replacing its enti
 ```ts title="app.component.ts"
 import { Component, AfterViewInit, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core'
 
+const DOC_URL = 'https://www.uxopian.com/hubfs/PDFReference15_v5.pdf'
+
 @Component({
   selector: 'app-root',
   standalone: true,
@@ -236,12 +250,14 @@ import { Component, AfterViewInit, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core'
   template: `
     <arender-element
       rendition="http://localhost:4200/"
-      url="https://www.uxopian.com/hubfs/PDFReference15_v5.pdf"
+      [attr.document]="documentParams"
       style="display: block; width: 100%; height: 100vh"
     ></arender-element>
   `,
 })
 export class AppComponent implements AfterViewInit {
+  documentParams = 'url=' + encodeURIComponent(DOC_URL)
+
   ngAfterViewInit() {
     import('arender-ui')
   }
@@ -259,15 +275,24 @@ Add the following to your `index.html` file, just before the closing `</body>` t
 
 ```html title="index.html"
 <arender-element
+  id="viewer"
   rendition="/"
-  url="https://www.uxopian.com/hubfs/PDFReference15_v5.pdf"
   style="display: block; width: 100%; height: 100vh"
 ></arender-element>
 
 <script type="module">
+  const DOC_URL = 'https://www.uxopian.com/hubfs/PDFReference15_v5.pdf'
+
+  document.getElementById('viewer')
+    .setAttribute('document', 'url=' + encodeURIComponent(DOC_URL))
+
   import('arender-ui')
 </script>
 ```
+
+:::note
+A plain HTML attribute cannot compute its own value, so the encoding has to happen somewhere. Setting the attribute from a script — before importing `arender-ui`, since the attribute is read when the element mounts — keeps `encodeURIComponent` in charge. A literal `document="url=…"` also works, but only if you percent-encode the value by hand.
+:::
 
 </TabItem>
 </Tabs>
@@ -310,7 +335,9 @@ If the viewer loads but no document appears, double-check the proxy configuratio
 
 ## Step 5 — Load a document dynamically
 
-To change the displayed document at runtime, use `window.ARender`. Calls made before the viewer finishes mounting are queued automatically — no need to wait for any event.
+To change the displayed document at runtime, call `window.ARender.openDocument(params)` with the same query string the `document` attribute takes. The most recent call wins, and calls made before the viewer finishes mounting are queued automatically — no need to wait for any event.
+
+The examples below wrap the document URL in `encodeURIComponent`: the viewer forwards your parameters to the backend untouched, so encoding each value is the caller's responsibility. It matters as soon as a value carries its own query string, such as a pre-signed URL.
 
 <Tabs>
 <TabItem value="react" label="React">
@@ -326,8 +353,7 @@ declare module 'react' {
     interface IntrinsicElements {
       'arender-element': React.HTMLAttributes<HTMLElement> & {
         rendition?: string
-        url?: string
-        uuid?: string
+        document?: string
       }
     }
   }
@@ -336,19 +362,24 @@ declare global {
   interface Window { ARender: ARenderHTMLElement }
 }
 
+const DOC_URL = 'https://www.uxopian.com/hubfs/PDFReference15_v5.pdf'
+const MAIL_URL = 'https://www.uxopian.com/hubfs/ARender-Mail_viewer_use_case.msg'
+
 function App() {
   useEffect(() => { import('arender-ui') }, [])
+
+  function changeDocument() {
+    window.ARender.openDocument(`url=${encodeURIComponent(MAIL_URL)}`)
+  }
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
       <div>
-        <button onClick={() => window.ARender.openDocumentByUrl('https://www.uxopian.com/hubfs/ARender-Mail_viewer_use_case.msg')}>
-          Change document
-        </button>
+        <button onClick={changeDocument}>Change document</button>
       </div>
       <arender-element
         rendition="/"
-        url="https://www.uxopian.com/hubfs/PDFReference15_v5.pdf"
+        document={`url=${encodeURIComponent(DOC_URL)}`}
         style={{ flex: 1 }}
       />
     </div>
@@ -367,10 +398,14 @@ Replace your `src/App.vue` with the following complete file:
 <script setup lang="ts">
 import { onMounted } from 'vue'
 
+const DOC_URL = 'https://www.uxopian.com/hubfs/PDFReference15_v5.pdf'
+const MAIL_URL = 'https://www.uxopian.com/hubfs/ARender-Mail_viewer_use_case.msg'
+const documentParams = `url=${encodeURIComponent(DOC_URL)}`
+
 onMounted(() => { import('arender-ui') })
 
 function changeDocument() {
-  window.ARender.openDocumentByUrl('https://www.uxopian.com/hubfs/ARender-Mail_viewer_use_case.msg')
+  window.ARender.openDocument(`url=${encodeURIComponent(MAIL_URL)}`)
 }
 </script>
 
@@ -381,7 +416,7 @@ function changeDocument() {
     </div>
     <arender-element
       rendition="/"
-      url="https://www.uxopian.com/hubfs/PDFReference15_v5.pdf"
+      :document="documentParams"
       style="flex: 1"
     />
   </div>
@@ -397,10 +432,14 @@ Replace your `src/App.svelte` with the following complete file:
 <script lang="ts">
   import { onMount } from 'svelte'
 
+  const DOC_URL = 'https://www.uxopian.com/hubfs/PDFReference15_v5.pdf'
+  const MAIL_URL = 'https://www.uxopian.com/hubfs/ARender-Mail_viewer_use_case.msg'
+  const documentParams = `url=${encodeURIComponent(DOC_URL)}`
+
   onMount(() => { import('arender-ui') })
 
   function changeDocument() {
-    window.ARender.openDocumentByUrl('https://www.uxopian.com/hubfs/ARender-Mail_viewer_use_case.msg')
+    window.ARender.openDocument(`url=${encodeURIComponent(MAIL_URL)}`)
   }
 </script>
 
@@ -410,7 +449,7 @@ Replace your `src/App.svelte` with the following complete file:
   </div>
   <arender-element
     rendition="/"
-    url="https://www.uxopian.com/hubfs/PDFReference15_v5.pdf"
+    document={documentParams}
     style="flex: 1; display: block"
   ></arender-element>
 </div>
@@ -424,6 +463,9 @@ Replace your `src/app/app.component.ts` with the following complete file:
 ```ts title="app.component.ts"
 import { Component, AfterViewInit, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core'
 
+const DOC_URL = 'https://www.uxopian.com/hubfs/PDFReference15_v5.pdf'
+const MAIL_URL = 'https://www.uxopian.com/hubfs/ARender-Mail_viewer_use_case.msg'
+
 @Component({
   selector: 'app-root',
   standalone: true,
@@ -435,19 +477,21 @@ import { Component, AfterViewInit, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core'
       </div>
       <arender-element
         rendition="http://localhost:4200/"
-        url="https://www.uxopian.com/hubfs/PDFReference15_v5.pdf"
+        [attr.document]="documentParams"
         style="display: block; flex: 1"
       ></arender-element>
     </div>
   `,
 })
 export class AppComponent implements AfterViewInit {
+  documentParams = 'url=' + encodeURIComponent(DOC_URL)
+
   ngAfterViewInit() {
     import('arender-ui')
   }
 
   changeDocument() {
-    window.ARender.openDocumentByUrl('https://www.uxopian.com/hubfs/ARender-Mail_viewer_use_case.msg')
+    window.ARender.openDocument('url=' + encodeURIComponent(MAIL_URL))
   }
 }
 ```
@@ -463,17 +507,23 @@ Add the following to your `index.html`, just before the closing `</body>` tag:
     <button id="change-btn">Change document</button>
   </div>
   <arender-element
+    id="viewer"
     rendition="/"
-    url="https://www.uxopian.com/hubfs/PDFReference15_v5.pdf"
     style="display: block; flex: 1"
   ></arender-element>
 </div>
 
 <script type="module">
+  const DOC_URL = 'https://www.uxopian.com/hubfs/PDFReference15_v5.pdf'
+  const MAIL_URL = 'https://www.uxopian.com/hubfs/ARender-Mail_viewer_use_case.msg'
+
+  document.getElementById('viewer')
+    .setAttribute('document', 'url=' + encodeURIComponent(DOC_URL))
+
   import('arender-ui')
 
   document.getElementById('change-btn').addEventListener('click', () => {
-    window.ARender.openDocumentByUrl('https://www.uxopian.com/hubfs/ARender-Mail_viewer_use_case.msg')
+    window.ARender.openDocument('url=' + encodeURIComponent(MAIL_URL))
   })
 </script>
 ```
@@ -495,4 +545,5 @@ These public URLs can be used for testing (the demo rendition already authorizes
 - [Configuration](../installation/configuration.md) — reverse proxy, authentication, and BFF
 - [Feature availability](../overview/horizon.md#feature-availability) — what's available now and what's coming
 - [Web Component](../reference/web-component.md) — HTML attributes, JavaScript API, styling
+- [Opening documents](../guides/features/opening-documents.md) — multi-document, repository parameters, encoding rules
 - [Providers](../guides/integration/providers.md) — load documents from Alfresco, FileNet, or custom repositories

--- a/docs/arender/reference/web-component.md
+++ b/docs/arender/reference/web-component.md
@@ -17,15 +17,26 @@ The ARender viewer is delivered as a Web Component: `<arender-element>`. It wrap
 
 ```html
 <arender-element
+  id="viewer"
   rendition="/"
-  url="https://example.com/document.pdf"
   style="display: block; width: 100%; height: 100vh"
 ></arender-element>
 
 <script type="module">
+  document.getElementById('viewer')
+    .setAttribute('document', 'url=' + encodeURIComponent('https://example.com/document.pdf'))
+
   import('arender-ui')
 </script>
 ```
+
+In a framework, bind the attribute instead:
+
+```jsx
+<arender-element rendition="/" document={`url=${encodeURIComponent(docUrl)}`} />
+```
+
+Either way, `encodeURIComponent` does the escaping — see [Parameter contract](#parameter-contract).
 
 :::note
 The component has no intrinsic height — you must set a height explicitly (e.g. `height: 100vh` or a fixed pixel value), otherwise it will not be displayed correctly.
@@ -36,10 +47,15 @@ The component has no intrinsic height — you must set a height explicitly (e.g.
 | Attribute | Required | Description |
 |-----------|----------|-------------|
 | `rendition` | Yes | URL of the ARender rendition backend. Use `/` when proxied via Nginx or Ingress. |
-| `url` | No | URL of the document to open on startup. |
-| `uuid` | No | ARender document ID to open on startup. Alternative to `url`. |
+| `document` | No | Query string of the parameters identifying the document to open on startup. See [Parameter contract](#parameter-contract). |
 
-Set `url` or `uuid` as HTML attributes to open a document on load — no JavaScript needed. To change the document at runtime, use the [JavaScript API](#javascript-api).
+The `document` attribute is read **once, when the component mounts**. Changing its value afterwards has no effect — to display another document at runtime, call [`openDocument()`](#javascript-api).
+
+Its value follows the same rules as the JavaScript API, encoding included, so build it with `encodeURIComponent` rather than pasting a raw URL. A plain HTML attribute cannot compute its own value: either percent-encode it by hand, or set it from a script before importing `arender-ui`, as shown above.
+
+:::note
+The `rendition` attribute carries the backend location only. Document parameters appended to it are ignored.
+:::
 
 ## JavaScript API
 
@@ -53,19 +69,67 @@ Calls made before the viewer finishes mounting are queued automatically — no n
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `openDocumentByUrl(url)` | `Promise<void>` | Open a document from a URL |
-| `openDocument(documentId)` | `Promise<void>` | Open a document by its ARender document ID |
+| `openDocument(params)` | `Promise<void>` | Open a document from a query string of parameters. See [Parameter contract](#parameter-contract). |
 
 ### Examples
 
 ```javascript
-// Via the window global
-window.ARender.openDocumentByUrl('https://example.com/document.pdf');
+const docUrl = 'https://example.com/document.pdf';
 
-// Via the element instance
+// A document reachable over HTTP
+window.ARender.openDocument(`url=${encodeURIComponent(docUrl)}`);
+
+// Several documents displayed as a single multi-document
+window.ARender.openDocument(`url=${encodeURIComponent(urlA)}&url=${encodeURIComponent(urlB)}`);
+
+// An already-resolved ARender document ID
+window.ARender.openDocument('uuid=b64_dXJsPWh0dHA6Ly9leGFtcGxlLmNvbS9zYW1wbGUucGRm');
+
+// Repository parameters — Alfresco
+window.ARender.openDocument('nodeRef=4aa144a5-a0b1-4c2d-8e3f-1234567890ab&user=admin&alf_ticket=TICKET_xxx&versionLabel=1.0');
+
+// Via the element instance, when several viewers share the page
 const viewer = document.querySelector('arender-element');
-viewer.ARender.openDocumentByUrl('https://example.com/document.pdf');
+viewer.ARender.openDocument(`url=${encodeURIComponent(docUrl)}`);
 ```
+
+Each call replaces the displayed document: the most recent request wins.
+
+## Parameter contract
+
+Both entry points — the `document` attribute and `openDocument(params)` — take the same thing: **a query string of the parameters that identify your document**. The viewer does not interpret it. It forwards it verbatim to the backend, which resolves it into an ARender document ID.
+
+See [Providers](../guides/integration/providers.md) for the parameters each repository expects.
+
+### Encoding URL
+
+The viewer never decodes and re-encodes the string, so **every value must be URL-encoded by the caller**. In exchange, values are transmitted byte for byte: a signature, a token, or a nested query string survives untouched.
+
+```javascript
+const signedUrl = 'https://bucket.s3.amazonaws.com/doc.pdf?X-Amz-Signature=abc123&X-Amz-Expires=900';
+window.ARender.openDocument('url=' + encodeURIComponent(signedUrl));
+```
+
+Without `encodeURIComponent`, the separators inside the value are read as parameter separators and the request is silently corrupted:
+
+```javascript
+// Wrong — the backend receives two parameters, "url" and "v"
+window.ARender.openDocument('url=http://example.com/get?id=1&v=2');
+```
+
+### Repeated parameters keep their order
+
+Parameters are grouped by key, and each key keeps its own order. Two parallel lists therefore stay paired by index, which is how repositories such as FileNet or M-Files open several files at once:
+
+```javascript
+window.ARender.openDocument('objectType=0&docId=534&fileId=576&fileId=977&title=a.pdf&title=b.pdf');
+```
+
+### `uuid` is a reserved parameter name
+
+A lone `uuid` parameter means the document is **already resolved**: its value is an ARender document ID, which the viewer uses as-is. No repository call is made.
+
+Because of this, a repository must never use `uuid` as one of its own parameter names: no provider knows that name, and forwarding it produces an opaque backend error.
 
 ## Loading the package
 
@@ -99,6 +163,10 @@ The `arender-ui` package exports the `ARenderHTMLElement` type for typed access:
 import type { ARenderHTMLElement } from 'arender-ui';
 
 const viewer = document.querySelector('arender-element') as ARenderHTMLElement;
-await viewer.ARender.openDocumentByUrl('https://example.com/document.pdf');
+await viewer.ARender.openDocument('url=' + encodeURIComponent('https://example.com/document.pdf'));
 ```
- 
+
+## Related pages
+
+- [Opening documents](../guides/features/opening-documents.md): every supported way to request a document
+- [Providers](../guides/integration/providers.md): the parameters each repository expects

--- a/package-lock.json
+++ b/package-lock.json
@@ -245,6 +245,7 @@
             "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.46.3.tgz",
             "integrity": "sha512-hfpCIukPuwkrlwsYfJEWdU5R5bduBHEq2uuPcqmgPgNq5MSjmiNIzRuzxGZZgiBKcre6gZT00DR7G1AFn//wiQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@algolia/client-common": "5.46.3",
                 "@algolia/requester-browser-xhr": "5.46.3",
@@ -383,6 +384,7 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.6.tgz",
             "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.28.6",
                 "@babel/generator": "^7.28.6",
@@ -2217,6 +2219,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -2239,6 +2242,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -2348,6 +2352,7 @@
             "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
             "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
@@ -2769,6 +2774,7 @@
             "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
             "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
@@ -3794,6 +3800,7 @@
             "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.9.2.tgz",
             "integrity": "sha512-C5wZsGuKTY8jEYsqdxhhFOe1ZDjH0uIYJ9T/jebHwkyxqnr4wW0jTkB72OMqNjsoQRcb0JN3PcSeTwFlVgzCZg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@docusaurus/core": "3.9.2",
                 "@docusaurus/logger": "3.9.2",
@@ -4022,6 +4029,7 @@
             "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.9.2.tgz",
             "integrity": "sha512-IGUsArG5hhekXd7RDb11v94ycpJpFdJPkLnt10fFQWOVxAtq5/D7hT6lzc2fhyQKaaCE62qVajOMKL7OiAFAIA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@docusaurus/core": "3.9.2",
                 "@docusaurus/logger": "3.9.2",
@@ -4062,6 +4070,7 @@
             "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.9.2.tgz",
             "integrity": "sha512-6c4DAbR6n6nPbnZhY2V3tzpnKnGL+6aOsLvFL26VRqhlczli9eWG0VDUNoCQEPnGwDMhPS42UhSAnz5pThm5Ag==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@docusaurus/mdx-loader": "3.9.2",
                 "@docusaurus/module-type-aliases": "3.9.2",
@@ -4637,6 +4646,7 @@
             "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
             "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/mdx": "^2.0.0"
             },
@@ -6013,6 +6023,7 @@
             "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
             "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/core": "^7.21.3",
                 "@svgr/babel-preset": "8.1.0",
@@ -6650,6 +6661,7 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.8.tgz",
             "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "csstype": "^3.2.2"
             }
@@ -6987,6 +6999,7 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -7081,6 +7094,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -7126,6 +7140,7 @@
             "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.46.3.tgz",
             "integrity": "sha512-n/NdPglzmkcNYZfIT3Fo8pnDR/lKiK1kZ1Yaa315UoLyHymADhWw15+bzN5gBxrCA8KyeNu0JJD6mLtTov43lQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@algolia/abtesting": "1.12.3",
                 "@algolia/client-abtesting": "5.46.3",
@@ -7743,6 +7758,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -8064,6 +8080,7 @@
             "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
             "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@chevrotain/cst-dts-gen": "11.0.3",
                 "@chevrotain/gast": "11.0.3",
@@ -8835,6 +8852,7 @@
             "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
             "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
@@ -9154,6 +9172,7 @@
             "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
             "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10"
             }
@@ -9563,6 +9582,7 @@
             "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
             "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
             "license": "ISC",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -9930,7 +9950,8 @@
             "version": "0.0.1566079",
             "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1566079.tgz",
             "integrity": "sha512-MJfAEA1UfVhSs7fbSQOG4czavUp1ajfg6prlAN0+cmfa2zNjaIbvq8VneP7do1WAQQIvgNJWSMeP6UyI90gIlQ==",
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/dir-glob": {
             "version": "3.0.1",
@@ -10891,6 +10912,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -15640,6 +15662,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -16346,6 +16369,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -17249,6 +17273,7 @@
             "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
             "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
@@ -18193,6 +18218,7 @@
             "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
             "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -18202,6 +18228,7 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
             "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
@@ -18257,6 +18284,7 @@
             "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-6.0.0.tgz",
             "integrity": "sha512-YMMxTUQV/QFSnbgrP3tjDzLHRg7vsbMn8e9HAa8o/1iXoiomo48b7sk/kkmWEuWNDPJVlKSJRB6Y2fHqdJk+SQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/react": "*"
             },
@@ -18359,6 +18387,7 @@
             "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
             "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.12.13",
                 "history": "^4.9.0",
@@ -20385,7 +20414,8 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
+            "license": "0BSD",
+            "peer": true
         },
         "node_modules/tsyringe": {
             "version": "4.10.0",
@@ -20451,6 +20481,7 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "devOptional": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -20821,6 +20852,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -21122,6 +21154,7 @@
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.104.1.tgz",
             "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
@@ -21785,6 +21818,7 @@
             "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
             "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }


### PR DESCRIPTION
## Context

ARender Horizon used to expose three competing ways to open a document — a two-method JS API (`openDocument(id)` / `openDocumentByUrl(url)`), the `uuid` / `url` Web Component attributes (plus document params read from the `rendition` URL), and the browser URL. In 2026.2.0 these collapse into a single contract: a query string of parameters, passed either through `window.ARender.openDocument(params)` or the `document` attribute, and forwarded verbatim to `POST /registry/documents`.

Since no client integrates Horizon yet, the legacy paths are removed rather than deprecated. This PR brings the public documentation in line with that contract.

Only the Horizon documentation is touched. Every modified file is Horizon-only (`viewer: horizon` or `*.horizon.md`), so the Classic viewer documentation — where the old mechanisms remain valid — is untouched.

## What changed

### Reference and guides rewritten

- **`reference/web-component.md`** — single `document` attribute, single `openDocument(params)` method. New **Parameter contract** section covering encoding responsibility (with a pre-signed URL example and a worked counter-example), repeated-parameter ordering, and `uuid` as a reserved parameter name. New **Viewer URL parameters** section documenting `?locale=` and `?flags=` — previously undocumented — and stating that the address bar never opens a document.
- **`guides/features/opening-documents.horizon.md`** — rewritten. The page was built entirely around browser-URL parameters. It now documents the two entry points, opening from a repository, opening an already-resolved id, and the three multi-document modes. "Multiple URL parameters: not supported yet" is replaced by the supported `url=a&url=b` form. New section listing what does *not* open a document (address bar, and "nothing requested" → default document).
- **`quickstart/getting-started.md`** — the five framework tabs (React, Vue, Svelte, Angular, plain HTML) updated across both the embed step and the runtime step: `document` attribute, single API method, and `encodeURIComponent` applied consistently through each framework's binding syntax. In plain HTML the attribute is set from a script, since a literal attribute cannot compute its own value.

### Integration guides aligned

- **`guides/integration/providers.md`** — the flow now states that the query string reaches the provider verbatim, never re-encoded or reordered, and that a lone `uuid` short-circuits any provider call. `uuid` is documented as reserved on the provider side.
- **`alfresco.horizon.md`, `filenet.horizon.md`, `m-files.horizon.md`** — each request-parameter table gains the corresponding `openDocument()` call. The "sample use case" flows no longer say the application "builds the viewer URL". Alfresco gains a troubleshooting row for the opaque `500` / null `alf_ticket` symptom caused by unencoded values. M-Files documents the client-side form of the repeated `fileId` / `title` pairing.

### Consistency fixes

- **`guides/upgrade/migration-from-gwt.md`** — one API method instead of two, plus an explicit mapping for the migration step that was missing: document parameters move out of the iframe URL query string and into `openDocument(params)`.
- **`concepts/documents-and-ids.horizon.md`** — document IDs no longer travel through viewer URLs; `uuid` documented as the only parameter name the viewer interprets itself.
- **`installation/docker-compose.horizon.md`** — the `DSB_AUTHORIZED_URLS` step no longer references `openDocumentByUrl`.

### Drive-by

Seven leftover "Modern viewer" mentions and references to the `react-arender-ui` / `angular-arender-ui` wrappers (removed in 2026.1.0) in the three Horizon connector guides.