### PR TITLE
AR-18312 — Horizon: annotation endpoints, Cloudsmith repo, comment annotation

### DIFF
--- a/docs/arender/installation/configuration.md
+++ b/docs/arender/installation/configuration.md
@@ -17,13 +17,14 @@ Backend rendition configuration (broker, converter, renderer) is documented in [
 
 ## API routes reference
 
-The viewer uses three API route prefixes, all proxied to the Document Service Broker:
+The viewer uses two API route prefixes, both proxied to the Document Service Broker:
 
 | Route | Purpose |
 |-------|---------|
-| `/documents/*` | Document rendering, page images, text extraction |
-| `/annotation/*` | Annotation CRUD operations |
+| `/documents/*` | Document rendering, page images, text extraction, annotation CRUD |
 | `/registry/documents` | Load documents through connector providers |
+
+Annotation operations are addressed under the document they belong to — `/documents/{documentId}/annotations` for the collection, `/documents/{documentId}/annotations/{annotationId}` for a single annotation — so no separate annotation route needs to be proxied.
 
 ## Proxy setup
 
@@ -49,7 +50,6 @@ export default {
   server: {
     proxy: {
       '/documents': { target: 'http://localhost:8761', changeOrigin: true },
-      '/annotation': { target: 'http://localhost:8761', changeOrigin: true },
       '/registry/documents': { target: 'http://localhost:8761', changeOrigin: true },
     },
   },
@@ -60,7 +60,7 @@ Vite forwards matching requests to the broker. The browser only sees `localhost`
 
 ### Same origin via existing infrastructure
 
-If your organization already routes the ARender API paths (`/documents`, `/annotation`, `/registry/documents`) to the broker under the same domain as your application — through an existing reverse proxy, load balancer, or API gateway — the browser sees all requests as same-origin and no additional configuration is needed.
+If your organization already routes the ARender API paths (`/documents`, `/registry/documents`) to the broker under the same domain as your application — through an existing reverse proxy, load balancer, or API gateway — the browser sees all requests as same-origin and no additional configuration is needed.
 
 ## Authentication and BFF
 
@@ -72,7 +72,7 @@ The BFF sits between the browser and the broker:
 
 1. It handles the OAuth2 flow (authorization code grant, token refresh).
 2. It stores tokens server-side — tokens are never exposed to the browser.
-3. It proxies the three ARender API routes, injecting `Authorization: Bearer <token>` on each request to the broker.
+3. It proxies the ARender API routes, injecting `Authorization: Bearer <token>` on each request to the broker.
 
 From the viewer's perspective, it calls the BFF exactly as it would call the broker — no change is needed in how you configure the `rendition` attribute on `<arender-element>`.
 
@@ -80,8 +80,7 @@ From the viewer's perspective, it calls the BFF exactly as it would call the bro
 
 | Route | Purpose |
 |-------|---------|
-| `/documents/*` | Document rendering |
-| `/annotation/*` | Annotation CRUD |
+| `/documents/*` | Document rendering, annotation CRUD |
 | `/registry/documents` | Connector providers |
 
 If you use [providers](../guides/integration/providers.md), the BFF must also inject the `X-Provider-ID` header on `/registry/documents` requests.

--- a/docs/arender/installation/docker-compose.horizon.md
+++ b/docs/arender/installation/docker-compose.horizon.md
@@ -113,10 +113,6 @@ server {
         proxy_pass http://service-broker:8761/documents;
     }
 
-    location /annotation {
-        proxy_pass http://service-broker:8761/annotation;
-    }
-
     location /registry/documents {
         proxy_pass http://service-broker:8761/registry/documents;
         # If using providers, inject the provider header:

--- a/docs/arender/overview/horizon.md
+++ b/docs/arender/overview/horizon.md
@@ -23,6 +23,7 @@ ARender Horizon is a React-based document viewer distributed as an npm package (
 | Print | Available |
 | Internationalization (15 languages) | Available |
 | Web Component | Available |
+| Comment annotation | Available |
 | Full annotation types (zone highlight, freetext, text highlight, rectangle, stamp, arrow, ink, sticky note...) | Coming soon |
 | Document comparison (text and image) | Coming soon |
 | Split, merge, page manipulation (document builder) | Coming soon |

--- a/docs/arender/quickstart/getting-started.md
+++ b/docs/arender/quickstart/getting-started.md
@@ -36,7 +36,7 @@ import TabItem from '@theme/TabItem';
 Open a terminal at the root of your project and install the `arender-ui` package:
 
 ```bash
-npm install arender-ui@{{version}} --registry=https://npm.cloudsmith.io/uxopian/arender-horizon
+npm install arender-ui@{{version}} --registry=https://npm.cloudsmith.io/uxopian/uxopian-public
 ```
 
 ## Step 2 — Configure the dev server proxy

--- a/docs/arender/quickstart/getting-started.md
+++ b/docs/arender/quickstart/getting-started.md
@@ -68,10 +68,6 @@ export default defineConfig({
         target: 'https://rendition.arender.2026.uxopian.com',
         changeOrigin: true,
       },
-      '/annotation': {
-        target: 'https://rendition.arender.2026.uxopian.com',
-        changeOrigin: true,
-      },
     },
   },
 })
@@ -85,8 +81,7 @@ Create a `proxy.conf.json` file at the root of your project:
 ```json title="proxy.conf.json"
 {
   "/documents":          { "target": "https://rendition.arender.2026.uxopian.com", "changeOrigin": true },
-  "/registry/documents": { "target": "https://rendition.arender.2026.uxopian.com", "changeOrigin": true },
-  "/annotation":         { "target": "https://rendition.arender.2026.uxopian.com", "changeOrigin": true }
+  "/registry/documents": { "target": "https://rendition.arender.2026.uxopian.com", "changeOrigin": true }
 }
 ```
 
@@ -109,7 +104,7 @@ Restart `ng serve` — the proxy is active immediately.
 :::tip
 To connect to your own backend instead of the demo, change each `target` to your backend URL (e.g. `http://localhost:8761` for Docker Compose). In production, replace the dev proxy with a reverse proxy (Nginx, Ingress) or a BFF. See [Docker Compose](../installation/docker-compose.md) for deployment guides.
 
-For other frameworks (Next.js, Nuxt, CRA, webpack…), configure your dev server proxy to forward `/documents`, `/registry/documents`, and `/annotation` to the rendition backend. Refer to your framework's documentation.
+For other frameworks (Next.js, Nuxt, CRA, webpack…), configure your dev server proxy to forward `/documents` and `/registry/documents` to the rendition backend. Annotation requests are served under `/documents/{documentId}/annotations`, so they are covered by the `/documents` prefix. Refer to your framework's documentation.
 :::
 
 ## Step 3 — Embed the viewer
@@ -305,7 +300,7 @@ If you use a different package manager, the equivalent command is:
 For other frameworks, use your usual start command (e.g. `npm start` for CRA).
 
 :::tip
-If the viewer loads but no document appears, double-check the proxy configuration in Step 3 — the `/documents`, `/registry/documents`, and `/annotation` paths must all be proxied to the rendition backend.
+If the viewer loads but no document appears, double-check the proxy configuration in Step 3 — the `/documents` and `/registry/documents` paths must both be proxied to the rendition backend.
 :::
 
 ## Step 5 — Load a document dynamically


### PR DESCRIPTION
Updates the ARender Horizon documentation to match three application-side changes. All
edits are scoped to Horizon — the Classic documentation is untouched.

### 1. Annotation endpoints moved under the document resource

The application no longer calls the root `/annotation` endpoint. Annotation requests are
now addressed under the document they belong to:

`/documents/{documentId}/annotations`            → collection
`/documents/{documentId}/annotations/{annotationId}` → single annotation



Because these paths fall under the already-proxied `/documents` prefix, the separate
`/annotation` proxy route is no longer needed. Removed it from every Horizon proxy example
and updated the surrounding prose:

| File | Change |
|------|--------|
| `docs/arender/quickstart/getting-started.md` | Vite proxy, Angular `proxy.conf.json`, and the two prose mentions (Step 2 tip, Step 4 troubleshooting tip) |
| `docs/arender/installation/configuration.md` | "API routes reference" table (3 → 2 prefixes) plus a note documenting the new paths, Vite proxy, "Same origin via existing infrastructure", BFF routes table |
| `docs/arender/installation/docker-compose.horizon.md` | Removed the `location /annotation` block from the Nginx configuration |

`docs/arender/guides/integration/providers.md` needed no change — its broker endpoint table
and sequence diagram already used `/documents/{id}/annotations`.

### 2. Web component published to a new Cloudsmith repository

The `arender-ui` package moved from the `arender-horizon` public repository to
`uxopian-public`. Updated the install command in `getting-started.md`:

```diff
- npm install arender-ui@{{version}} --registry=https://npm.cloudsmith.io/uxopian/arender-horizon
+ npm install arender-ui@{{version}} --registry=https://npm.cloudsmith.io/uxopian/uxopian-public
```


### 3. Comment annotation marked as available
Added a Comment annotation | Available row to the feature availability table in
`docs/arender/overview/horizon.md.`
