### PR TITLE
Update demo rendition backend URL in the Horizon quickstart

### DIFF
--- a/docs/arender/quickstart/getting-started.md
+++ b/docs/arender/quickstart/getting-started.md
@@ -44,7 +44,7 @@ npm install arender-ui@{{version}} --registry=https://npm.cloudsmith.io/uxopian/
 The viewer needs to reach the rendition backend. In development, your dev server's built-in proxy handles this — no external reverse proxy needed.
 
 :::note
-Uxopian provides a shared demo rendition backend at `https://rendition.arender.2026.uxopian.com` — available to all, no credentials or installation required. This lets you test the viewer right away. Deploying your own backend is covered in the [Installation](../installation/docker-compose.md) section.
+Uxopian provides a shared demo rendition backend at `https://rendition.demo.arender.uxopian.com` — available to all, no credentials or installation required. This lets you test the viewer right away. Deploying your own backend is covered in the [Installation](../installation/docker-compose.md) section.
 :::
 
 <Tabs>
@@ -61,11 +61,11 @@ export default defineConfig({
   server: {
     proxy: {
       '/documents': {
-        target: 'https://rendition.arender.2026.uxopian.com',
+        target: 'https://rendition.demo.arender.uxopian.com',
         changeOrigin: true,
       },
       '/registry/documents': {
-        target: 'https://rendition.arender.2026.uxopian.com',
+        target: 'https://rendition.demo.arender.uxopian.com',
         changeOrigin: true,
       },
     },
@@ -80,8 +80,8 @@ Create a `proxy.conf.json` file at the root of your project:
 
 ```json title="proxy.conf.json"
 {
-  "/documents":          { "target": "https://rendition.arender.2026.uxopian.com", "changeOrigin": true },
-  "/registry/documents": { "target": "https://rendition.arender.2026.uxopian.com", "changeOrigin": true }
+  "/documents":          { "target": "https://rendition.demo.arender.uxopian.com", "changeOrigin": true },
+  "/registry/documents": { "target": "https://rendition.demo.arender.uxopian.com", "changeOrigin": true }
 }
 ```
 


### PR DESCRIPTION
The shared demo rendition backend previously documented at `https://rendition.arender.2026.uxopian.com` has been disabled. This updates the Horizon quickstart to point at the new host, `https://rendition.demo.arender.uxopian.com`.

Changes, all in `docs/arender/quickstart/getting-started.md` (5 occurrences, the only ones in the repo):

- Step 2 note announcing the shared demo backend
- Vite dev-server proxy targets for `/documents` and `/registry/documents`
- Angular `proxy.conf.json` targets for the same two paths

The new URL was verified locally against the quickstart proxy setup.

Notes:

- The trailing slash was dropped for consistency with the surrounding formatting; it has no effect on a Vite or Angular proxy `target`.
- `last_update` and `content_hash` in the front matter are left untouched, since `scripts/updateLastModified.mjs` regenerates them at build time.