### PR TITLE
Promote staging to master: missing v2026.2.0 release note entries

### DIFF
--- a/src/generated/arenderReleases.json
+++ b/src/generated/arenderReleases.json
@@ -3,7 +3,7 @@
     "version": "v2026.2.0",
     "title": "ARender v2026.2.0 - Release Notes",
     "date": "2026-07-31",
-    "description": "Second minor on the 2026 line: a new M-Files provider, underline annotations and comments panel refinements in ARender Horizon, plus Classic annotation fixes, Rendition fixes and security hardening.",
+    "description": "Second minor on the 2026 line: a new M-Files provider, underline and circle annotations plus a single document-opening API in ARender Horizon, and Classic annotation fixes, Rendition fixes and security hardening.",
     "slug": "/release-note/arender/v2026.2.0/release-notes",
     "hasUpgradeNotes": true,
     "latest": true

--- a/src/pages/release-note/arender/v2026.2.0/release-notes.md
+++ b/src/pages/release-note/arender/v2026.2.0/release-notes.md
@@ -5,7 +5,7 @@ date: "2026-07-31"
 weight: -202602
 aliases:
   - /release/2026.2/
-description: "Second minor on the 2026 line: a new M-Files provider, underline annotations and comments panel refinements in ARender Horizon, plus Classic annotation fixes, Rendition fixes and security hardening."
+description: "Second minor on the 2026 line: a new M-Files provider, underline and circle annotations plus a single document-opening API in ARender Horizon, and Classic annotation fixes, Rendition fixes and security hardening."
 _build:
   list: never
 ---
@@ -16,7 +16,7 @@ import DocLink from '@site/src/components/DocLink';
 
 # ARender v2026.2.0 - Release Notes
 
-ARender 2026.2.0 is the second minor release on the 2026 line. It adds a new **M-Files provider** so documents can be viewed directly from M-Files vaults, continues to expand annotation tooling in **ARender Horizon** (underline annotations and comments panel refinements), and rounds out the release with Classic annotation fixes, Rendition fixes and security hardening.
+ARender 2026.2.0 is the second minor release on the 2026 line. It adds a new **M-Files provider** so documents can be viewed directly from M-Files vaults, continues to expand annotation tooling in **ARender Horizon** (underline and circle annotations, comments panel refinements), and unifies how a document is opened in Horizon behind a single API. The release is rounded out with Classic annotation fixes, Rendition fixes and security hardening.
 
 As in the previous release, the changes below are grouped by viewer: a shared **Security** section, then **ARender Horizon (React)**, **ARender Classic (GWT)**, and finally **Rendition & platform** for everything that applies to both viewers (backend, conversion, integrations).
 
@@ -46,9 +46,19 @@ Changes specific to the React viewer (ARender Horizon).
 
 `New` - ARender Horizon can now underline selected text, with a color palette to choose the underline color. This complements the highlight-on-selection tool added in 2026.1.0 and brings Horizon closer to annotation parity with Classic.
 
+#### Circle annotations
+
+`New` - A circle annotation tool is now available in ARender Horizon, so a round area of a page such as a logo or a stamp can be marked out directly in the viewer.
+
 #### Comments panel refinements
 
 `Changed` - The Horizon comments panel introduced in 2026.1.0 gains interactive comment pins on the document page, kept in sync both ways with the comment list: hovering a pin highlights the matching comment and scrolls it into view, and selecting a comment points back to its pin. Comments are also grouped by status (open and closed) so long discussions stay easy to scan.
+
+#### A single way to open a document
+
+`Changed` - ARender Horizon now opens documents through one contract, used by both entry points: `window.ARender.openDocument(params)` in the JavaScript API, and the `document` attribute on the `<arender-element>` Web Component. Both take the same query string of parameters, forwarded to the Rendition backend as-is, so an integration passes only the parameters its repository already expects (`nodeRef`, `objectStoreName`, `objectType`, `url`, `uuid`) without having to know the viewer's own conventions. Opening several documents at once and repeating a parameter now work identically on both entry points.
+
+The earlier entry points are removed: `openDocumentByUrl()`, the `uuid` and `url` attributes on the Web Component, document parameters carried by the `rendition` URL, and document loading from the browser URL. See the <DocLink version="v2026.2.0" product="arender" to="guides/features/opening-documents">opening documents guide</DocLink> for the parameter contract and per-repository examples.
 
 ---
 
@@ -107,8 +117,10 @@ Backend, conversion and integration changes that apply regardless of the viewer.
 | Dependency security update | Both | Security | AR-18522 | |
 | Dependency security update | Both | Security | AR-18561 | |
 | Add underline annotation with color selection | Horizon | Evolution | AR-18450 | |
+| Add circle annotation | Horizon | Evolution | AR-18428 | |
 | Group comments by status in the comments panel | Horizon | Evolution | AR-17923 | |
 | Interactive comment pins synchronized with the comment list | Horizon | Evolution | AR-17930 | |
+| Unify document loading behind a single openDocument(params) API and document attribute | Horizon | Evolution | AR-18575 | |
 | M-Files provider | Both | New feature | AR-18346 | |
 | Annotation selection indicator not displayed for circle and polygon annotations | Classic | Regression | AR-18466 | TMAPR-6864 |
 | Adding an annotation inside another one prevents the document from being displayed | Classic | Bug fix | AR-18477 | TMAPR-6886 |


### PR DESCRIPTION
## Content

Promotes `staging` to `master` so the v2026.2.0 release note fix reaches production. `deploy-prod` builds from `master`, so this merge is required before the prod deploy is run.

Delta over `master`, nothing else rides along:

```
7c486d69 Merge pull request #182 from Uxopian/fix/release-note-v2026.2.0-missing-entries
f7fe32e9 Add missing v2026.2.0 release note entries
```

Two files, +15 / -3:
- `src/pages/release-note/arender/v2026.2.0/release-notes.md`
- `src/generated/arenderReleases.json`

## Why

The v2026.2.0 release note was published on 2026-07-31, but the Jira version was only closed on 2026-08-06. Two customer-visible tickets were moved into fixVersion `2026.2.0` after publication and were therefore missing from the note:

- **AR-18428** circle annotation in ARender Horizon
- **AR-18575** unified document loading (`openDocument(params)` and the `document` attribute), including the removal of `openDocumentByUrl()`, the `uuid` / `url` Web Component attributes, rendition-URL document parameters and browser-URL loading

See #182 for the full arbitration, including the five tickets deliberately left out.

## Checks

- Staging build on `7c486d69` is green, so the new MDX compiles, DocLink included.
- The `guides/features/opening-documents` DocLink resolves: `arenderVersion` is `2026.2.0` on master and the `current` version label is `v${arenderVersion}`, with no `arender-v2026.2.0` snapshot branch, so the link targets the current doc tree where the page exists.
- The release date stays at `2026-07-31`. The real GA per Jira is 2026-08-06; deliberately not corrected.

## After merge

Run the **Deploy to PRODUCTION (Manual)** workflow. The last prod deploy ran on `e7bccb6c`, one minute before this fix landed on staging, so production does not have it yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
